### PR TITLE
framework for register objects

### DIFF
--- a/src/compas_viewer/__init__.py
+++ b/src/compas_viewer/__init__.py
@@ -34,5 +34,9 @@ TEMP = os.path.abspath(os.path.join(HOME, "temp"))
 
 __all__ = ["HOME", "DATA", "DOCS", "TEMP"]
 
+__all_plugins__ = [
+    "compas_viewer.scene",
+]
+
 # Putting imports here to avoid circular imports
 from .viewer import Viewer  # noqa: F401, E402

--- a/src/compas_viewer/scene/__init__.py
+++ b/src/compas_viewer/scene/__init__.py
@@ -1,3 +1,38 @@
 """
 The Viewer implemeation of scene and scene objects are here.
 """
+
+
+from compas.plugins import plugin
+from compas.scene import register
+
+from compas.geometry import Box
+from compas.geometry import Sphere
+
+from .sceneobject import ViewerSceneObject
+from .boxobject import BoxObject
+from .sphereobject import SphereObject
+
+
+@plugin(category="drawing-utils", requires=["compas_viewer"])
+def clear(guids=None):
+    pass
+
+
+@plugin(category="drawing-utils", requires=["compas_viewer"])
+def redraw():
+    pass
+
+
+@plugin(category="factories", requires=["compas_viewer"])
+def register_scene_objects():
+    register(Box, BoxObject, context="Viewer")
+    register(Sphere, SphereObject, context="Viewer")
+    # register other scene objects here
+
+
+__all__ = [
+    "ViewerSceneObject",
+    "BoxObject",
+    "SphereObject",
+]

--- a/src/compas_viewer/scene/boxobject.py
+++ b/src/compas_viewer/scene/boxobject.py
@@ -1,0 +1,22 @@
+from compas.scene import GeometryObject
+from .sceneobject import ViewerSceneObject
+
+
+class BoxObject(ViewerSceneObject, GeometryObject):
+    """Scene object for drawing box shapes.
+
+    Parameters
+    ----------
+    box : :class:`compas.geometry.Box`
+        A COMPAS box.
+    **kwargs : dict, optional
+        Additional keyword arguments.
+
+    """
+
+    def __init__(self, box, **kwargs):
+        super(BoxObject, self).__init__(geometry=box, **kwargs)
+
+    def draw(self):
+        """Draw the box associated with the object."""
+        raise NotImplementedError

--- a/src/compas_viewer/scene/sceneobject.py
+++ b/src/compas_viewer/scene/sceneobject.py
@@ -1,0 +1,11 @@
+from compas.scene import SceneObject
+
+
+class ViewerSceneObject(SceneObject):
+    """Base class for all Viewer scene objects."""
+
+    def __init__(self, **kwargs):
+        super(ViewerSceneObject, self).__init__(**kwargs)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.geometry})"

--- a/src/compas_viewer/scene/sphereobject.py
+++ b/src/compas_viewer/scene/sphereobject.py
@@ -1,0 +1,22 @@
+from compas.scene import GeometryObject
+from .sceneobject import ViewerSceneObject
+
+
+class SphereObject(ViewerSceneObject, GeometryObject):
+    """Scene object for drawing sphere shapes.
+
+    Parameters
+    ----------
+    box : :class:`compas.geometry.Sphere`
+        A COMPAS sphere.
+    **kwargs : dict, optional
+        Additional keyword arguments.
+
+    """
+
+    def __init__(self, sphere, **kwargs):
+        super(SphereObject, self).__init__(geometry=sphere, **kwargs)
+
+    def draw(self):
+        """Draw the box associated with the object."""
+        raise NotImplementedError


### PR DESCRIPTION
An example for registering object using latest `Scene` infrastructure at COMPAS 2.
```python
from compas.scene import Scene
from compas.geometry import Box
from compas.geometry import Sphere


box = Box.from_width_height_depth(1, 1, 1)
sphere = Sphere(1)

# Scene should be later added as an attribute of Viewer and created internally at Viewer.__init__()
scene = Scene(context='Viewer')
boxObj = scene.add(box)
scene.add(sphere, parent=boxObj)

scene.print_hierarchy()
```
Then it will print this:
```
└── <TreeNode root>
    └── <TreeNode Box>
        └── <TreeNode Sphere>
```