### PR TITLE
Separate `Viewer` and `Scene` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved argument passing mechanism in the `Slider` class. Close [#76](https://github.com/compas-dev/compas_viewer/issues/76).
 * Documentation images and code correction.
 * Improved typing hints of `CollectionObject`.
+* Bug fix of [#73](https://github.com/compas-dev/compas_viewer/issues/73).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `RobotModelObject` and its example in the documentation.
 
 ### Changed
+* Added `ViewerScene` as an attribute of the `Viewer` class. resolve [#28](https://github.com/compas-dev/compas_viewer/issues/28).
 * Documentation images and code correction.
 * Improved typing hints of `CollectionObject`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `RobotModelObject` and its example in the documentation.
 
 ### Changed
+
 * Added `ViewerScene` as an attribute of the `Viewer` class. resolve [#28](https://github.com/compas-dev/compas_viewer/issues/28).
+* Improved argument passing mechanism in the `Slider` class. Close [#76](https://github.com/compas-dev/compas_viewer/issues/76).
 * Documentation images and code correction.
 * Improved typing hints of `CollectionObject`.
 

--- a/docs/examples/color/blending.py
+++ b/docs/examples/color/blending.py
@@ -21,8 +21,8 @@ facescolor = {k: Color(random(), random(), random()) for k in mesh.faces()}
 linescolor = {k: Color(random(), random(), random()) for k in mesh.edges()}
 pointscolor = {k: Color(random(), random(), random()) for k in mesh.vertices()}
 
-viewer.add(mesh, name="mesh1", show_points=True, facescolor=facescolor, linescolor=linescolor, pointscolor=pointscolor)  # type: ignore
-viewer.add(
+viewer.scene.add(mesh, name="mesh1", show_points=True, facescolor=facescolor, linescolor=linescolor, pointscolor=pointscolor)  # type: ignore
+viewer.scene.add(
     mesh2,
     name="mesh2",
     show_points=True,

--- a/docs/examples/color/colors.py
+++ b/docs/examples/color/colors.py
@@ -8,13 +8,13 @@ from compas_viewer import Viewer
 viewer = Viewer()
 
 box = Box(1, 1, 1, Frame((0, 0, 0), [1, 0, 0], [0, 1, 0]))
-obj1 = viewer.add(box, facescolor=Color(1.0, 0.0, 0.0), opacity=0.7)
+obj1 = viewer.scene.add(box, facescolor=Color(1.0, 0.0, 0.0), opacity=0.7)
 
 box = Box(1, 1, 1, Frame((0, 0, 0), [1, 0, 0], [0, 1, 0]))
-obj2 = viewer.add(box, facescolor=Color(0.0, 1.0, 0.0), opacity=0.7)
+obj2 = viewer.scene.add(box, facescolor=Color(0.0, 1.0, 0.0), opacity=0.7)
 
 box = Box(1, 1, 1, Frame((0, 0, 0), [1, 0, 0], [0, 1, 0]))
-obj3 = viewer.add(box, facescolor=Color(0.0, 0.0, 1.0), opacity=0.7)
+obj3 = viewer.scene.add(box, facescolor=Color(0.0, 0.0, 1.0), opacity=0.7)
 
 
 obj2.transformation = Translation.from_vector([2, 0, 0])

--- a/docs/examples/color/face_vertext_color.py
+++ b/docs/examples/color/face_vertext_color.py
@@ -13,6 +13,6 @@ mesh = Mesh.from_obj(compas.get("faces.obj"))
 for vertex in mesh.vertices():
     mesh.vertex_attribute(vertex, "color", Color.from_i(random()))
 
-viewer.add(mesh, use_vertexcolors=True)
+viewer.scene.add(mesh, use_vertexcolors=True)
 
 viewer.show()

--- a/docs/examples/dynamic/dynamic.py
+++ b/docs/examples/dynamic/dynamic.py
@@ -5,7 +5,7 @@ from compas_viewer import Viewer
 from compas_viewer.scene import PointObject
 
 viewer = Viewer()
-obj: PointObject = viewer.add(Point(0, 0, 0), show_points=True, pointscolor=Color.red(), pointsize=10)  # type: ignore
+obj: PointObject = viewer.scene.add(Point(0, 0, 0), show_points=True, pointscolor=Color.red(), pointsize=10)  # type: ignore
 
 
 @viewer.on(interval=1000)

--- a/docs/examples/dynamic/dynamic_mesh.py
+++ b/docs/examples/dynamic/dynamic_mesh.py
@@ -9,7 +9,7 @@ from compas_viewer import Viewer
 viewer = Viewer()
 
 mesh = Mesh.from_off(compas.get("tubemesh.off"))
-obj = viewer.add(mesh, facescolor=Color.cyan(), use_vertexcolors=False)
+obj = viewer.scene.add(mesh, facescolor=Color.cyan(), use_vertexcolors=False)
 
 
 @viewer.on(interval=1000)

--- a/docs/examples/dynamic/orbiting.py
+++ b/docs/examples/dynamic/orbiting.py
@@ -15,7 +15,7 @@ viewer.renderer.camera.rotation.x = 10
 viewer.renderer.camera.rotation.y = 10
 viewer.renderer.camera.distance = 5
 
-viewer.add(sphere, facescolor=Color.cyan(), linescolor=Color.blue())
+viewer.scene.add(sphere, facescolor=Color.cyan(), linescolor=Color.blue())
 
 
 @viewer.on(interval=50)

--- a/docs/examples/dynamic/transform.py
+++ b/docs/examples/dynamic/transform.py
@@ -11,9 +11,9 @@ viewer = Viewer()
 box1 = Box(1, 1, 1, Frame([0, 0, 0], [1, 0, 0], [0, 1, 0]))
 box2 = Box(1, 1, 1, Frame([0, 0, 0], [1, 0, 0], [0, 1, 0]))
 box3 = Box(1, 1, 1, Frame([0, 0, 0], [1, 0, 0], [0, 1, 0]))
-obj1 = viewer.add(box1, facescolor=Color.red())
-obj2 = viewer.add(box2, facescolor=Color.blue())
-obj3 = viewer.add(box3, facescolor=Color.green())
+obj1 = viewer.scene.add(box1, facescolor=Color.red())
+obj2 = viewer.scene.add(box2, facescolor=Color.blue())
+obj3 = viewer.scene.add(box3, facescolor=Color.green())
 
 s = 1
 

--- a/docs/examples/layout/slider.py
+++ b/docs/examples/layout/slider.py
@@ -12,8 +12,8 @@ curve = Bezier([[0, 0, 0], [3, 6, 0], [5, -3, 0], [10, 0, 0]])
 viewer = Viewer(rendermode="shaded", width=1600, height=900)
 
 
-pointobj: PointObject = viewer.add(Point(*curve.point_at(0)), pointssize=20, pointscolor=Color.red(), show_points=True)  # type: ignore
-curveobj = viewer.add(Polyline(curve.to_polyline()), lineswidth=2, linescolor=Color.blue())
+pointobj: PointObject = viewer.scene.add(Point(*curve.point_at(0)), pointssize=20, pointscolor=Color.red(), show_points=True)  # type: ignore
+curveobj = viewer.scene.add(Polyline(curve.to_polyline()), lineswidth=2, linescolor=Color.blue())
 
 
 def slide(value):

--- a/docs/examples/layout/slider.py
+++ b/docs/examples/layout/slider.py
@@ -16,8 +16,9 @@ pointobj: PointObject = viewer.scene.add(Point(*curve.point_at(0)), pointssize=2
 curveobj = viewer.scene.add(Polyline(curve.to_polyline()), lineswidth=2, linescolor=Color.blue())
 
 
-def slide(value):
+def slide(value, additional_var):
     value = value / 100
+    print(additional_var + str(value))
     pointobj.geometry = curve.point_at(value)
     pointobj.init()
     pointobj.update()
@@ -25,14 +26,7 @@ def slide(value):
 
 
 viewer.layout.sidedock.add_element(
-    Slider(
-        slide,
-        0,
-        0,
-        100,
-        1,
-        "Slide Point",
-    )
+    Slider(slide, 0, 0, 100, 1, "Slide Point", additional_var="Slide the point along the curve at ")
 )
 
 

--- a/docs/examples/layout/tree.py
+++ b/docs/examples/layout/tree.py
@@ -9,10 +9,10 @@ viewer = Viewer(rendermode="shaded")
 viewer = Viewer()
 for i in range(10):
     for j in range(10):
-        sp = viewer.add(Sphere(1, Frame([10*i, 10*j, 0], [1, 0, 0], [0, 1, 0])), name=f"Sphere_{i}_{j}")
+        sp = viewer.scene.add(Sphere(1, Frame([10*i, 10*j, 0], [1, 0, 0], [0, 1, 0])), name=f"Sphere_{i}_{j}")
 
 
-viewer.layout.sidedock.add_element(Treeform(viewer._tree, {"Name": ".object.name", "Object": ".object"}))
+viewer.layout.sidedock.add_element(Treeform(viewer.scene.tree, {"Name": ".object.name", "Object": ".object"}))
 
 
 viewer.show()

--- a/docs/examples/object/arrows.py
+++ b/docs/examples/object/arrows.py
@@ -10,6 +10,6 @@ viewer = Viewer()
 
 for x in range(5):
     for y in range(5):
-        viewer.add(Vector(0, 0, 1), anchor=Point(x, y, 0), linescolor=Color.from_i(random()))
+        viewer.scene.add(Vector(0, 0, 1), anchor=Point(x, y, 0), linescolor=Color.from_i(random()))
 
 viewer.show()

--- a/docs/examples/object/brep.py
+++ b/docs/examples/object/brep.py
@@ -7,5 +7,5 @@ box = Box(1, 1, 1, Frame.worldXY())
 brep = OCCBrep.from_box(box)
 
 viewer = Viewer()
-viewer.add(brep)
+viewer.scene.add(brep)
 viewer.show()

--- a/docs/examples/object/fonts.py
+++ b/docs/examples/object/fonts.py
@@ -17,14 +17,14 @@ def find_sys_font(font_name: str) -> PathLike:  # type: ignore
 
 # By default, the text is rendered using the FreeSans font from the library.
 t = Tag("EN", (0, 0, 0), height=50)
-viewer.add(t)
+viewer.scene.add(t)
 
 # Font specified is possible.
 t = Tag("EN", (3, 0, 0), height=50, font=find_sys_font("Times New Roman"))
-viewer.add(t)
+viewer.scene.add(t)
 
 # Multi-language text is possible if the machine has the font installed.
 t = Tag("中文 CN", (3, 3, 0), height=50, font=find_sys_font("DengXian"))
-viewer.add(t)
+viewer.scene.add(t)
 
 viewer.show()

--- a/docs/examples/object/frames.py
+++ b/docs/examples/object/frames.py
@@ -6,6 +6,6 @@ viewer = Viewer()
 
 frame = Frame([1, 1, 1], [0.68, 0.68, 0.27], [-0.67, 0.73, -0.15])
 
-viewer.add(frame)
+viewer.scene.add(frame)
 
 viewer.show()

--- a/docs/examples/object/geometries.py
+++ b/docs/examples/object/geometries.py
@@ -14,32 +14,32 @@ from compas_viewer import Viewer
 viewer = Viewer()
 
 polygon = Polygon([[0, 0, 0], [1, 0, 0], [1, 1, 0]])
-obj = viewer.add(polygon, linescolor=Color(0.0, 0.0, 1.0))
+obj = viewer.scene.add(polygon, linescolor=Color(0.0, 0.0, 1.0))
 
 frame = Frame([0, 0, 0], [0, 0, 1])
-obj = viewer.add(frame, size=0.5, linescolor=Color(1.0, 0.0, 0.0), facescolor=Color(0.0, 0.0, 1.0))
+obj = viewer.scene.add(frame, size=0.5, linescolor=Color(1.0, 0.0, 0.0), facescolor=Color(0.0, 0.0, 1.0))
 obj.transformation = Translation.from_vector(Vector(5, 0, 0))
 
 circle = Circle(0.8, frame)
-obj = viewer.add(circle, linescolor=Color(0.0, 1.0, 0.0))
+obj = viewer.scene.add(circle, linescolor=Color(0.0, 1.0, 0.0))
 obj.transformation = Translation.from_vector(Vector(10, 0, 0))
 
 ellipse = Ellipse(1.5, 0.5, frame)
-obj = viewer.add(ellipse, linescolor=Color(1.0, 0.0, 1.0))
+obj = viewer.scene.add(ellipse, linescolor=Color(1.0, 0.0, 1.0))
 obj.transformation = Translation.from_vector(Vector(0, 5, 0))
 
 cone = Cone(circle.radius, 1.5)
-obj = viewer.add(cone, facescolor=Color(1.0, 0.0, 0.0))
+obj = viewer.scene.add(cone, facescolor=Color(1.0, 0.0, 0.0))
 obj.transformation = Translation.from_vector(Vector(5, 5, 0))
 
 vertices = [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 0, 1]]
 faces = [[0, 1, 2], [0, 1, 3], [1, 2, 3], [0, 2, 3]]
 polyhedron = Polyhedron(vertices, faces)
-obj = viewer.add(polyhedron.to_mesh(), facescolor=Color(0.0, 1.0, 0.0))
+obj = viewer.scene.add(polyhedron.to_mesh(), facescolor=Color(0.0, 1.0, 0.0))
 obj.transformation = Translation.from_vector(Vector(10, 5, 0))
 
 capsule = Capsule(1, 0.3)
-obj = viewer.add(capsule, facescolor=Color(0.0, 0.0, 1.0))
+obj = viewer.scene.add(capsule, facescolor=Color(0.0, 0.0, 1.0))
 obj.transformation = Translation.from_vector(Vector(0, 10, 0))
 
 viewer.show()

--- a/docs/examples/object/lines.py
+++ b/docs/examples/object/lines.py
@@ -9,6 +9,6 @@ viewer = Viewer()
 
 for i in range(10):
     line = Line([random() * 20, random() * 20, random() * 20], [random() * 20, random() * 20, random() * 20])
-    viewer.add(line, linescolor=Color(random(), random(), random()))
+    viewer.scene.add(line, linescolor=Color(random(), random(), random()))
 
 viewer.show()

--- a/docs/examples/object/mesh_display.py
+++ b/docs/examples/object/mesh_display.py
@@ -14,7 +14,7 @@ mesh.transform(T * S)
 
 mesh2 = mesh.transformed(Translation.from_vector([-6, 0, 0]))
 
-viewer.add(mesh, hide_coplanaredges=False)
-viewer.add(mesh2, hide_coplanaredges=True)
+viewer.scene.add(mesh, hide_coplanaredges=False)
+viewer.scene.add(mesh2, hide_coplanaredges=True)
 
 viewer.show()

--- a/docs/examples/object/nurbs.py
+++ b/docs/examples/object/nurbs.py
@@ -1,7 +1,8 @@
-from compas.geometry import Point
-from compas.geometry import NurbsSurface
-from compas_viewer import Viewer
 from compas.colors import Color
+from compas.geometry import NurbsSurface
+from compas.geometry import Point
+
+from compas_viewer import Viewer
 
 points = [
     [Point(0, 0, 0), Point(1, 0, 0), Point(2, 0, 0), Point(3, 0, 0)],
@@ -12,6 +13,8 @@ points = [
 
 surface = NurbsSurface.from_points(points=points)
 
-view = Viewer(rendermode="lighted")
-view.add(surface, show_points=True, show_lines=True, pointscolor=Color(1.0, 0.0, 0.0), linescolor=Color(0.0, 0.0, 1.0))
-view.show()
+viewer = Viewer(rendermode="lighted")
+viewer.scene.add(
+    surface, show_points=True, show_lines=True, pointscolor=Color(1.0, 0.0, 0.0), linescolor=Color(0.0, 0.0, 1.0)
+)
+viewer.show()

--- a/docs/examples/object/points.py
+++ b/docs/examples/object/points.py
@@ -8,6 +8,6 @@ from compas_viewer import Viewer
 viewer = Viewer()
 for i in range(10):
     point = Point(random() * 10, random() * 10, random() * 10)
-    viewer.add(point, pointscolor=Color(random(), random(), random()), pointssize=30, show_points=True)
+    viewer.scene.add(point, pointscolor=Color(random(), random(), random()), pointssize=30, show_points=True)
 
 viewer.show()

--- a/docs/examples/object/points.py
+++ b/docs/examples/object/points.py
@@ -8,6 +8,7 @@ from compas_viewer import Viewer
 viewer = Viewer()
 for i in range(10):
     point = Point(random() * 10, random() * 10, random() * 10)
-    viewer.scene.add(point, pointscolor=Color(random(), random(), random()), pointssize=30, show_points=True)
+    viewer.scene.add(point, pointscolor=Color(random(), random(), random()), pointssize=30)
+
 
 viewer.show()

--- a/docs/examples/object/polyline.py
+++ b/docs/examples/object/polyline.py
@@ -12,13 +12,13 @@ for i in range(10):
     pts.append([random.uniform(0, 10), random.uniform(0, 10), random.uniform(0, 10)])
 
 polyline = Polyline(pts)
-viewer.add(polyline, show_points=True, pointscolor=Color(1.0, 0.0, 1.0), linescolor=Color(1.0, 0.0, 1.0), lineswidth=1)
+viewer.scene.add(polyline, show_points=True, pointscolor=Color(1.0, 0.0, 1.0), linescolor=Color(1.0, 0.0, 1.0), lineswidth=1)
 
 pts = []
 for i in range(5):
     pts.append([random.uniform(0, 10), random.uniform(0, 10), random.uniform(0, 10)])
 
 polyline = Polyline(pts)
-viewer.add(polyline, show_points=True, pointscolor=Color(0.0, 0.0, 1.0), linescolor=Color(1.0, 0.0, 0.0), lineswidth=5)
+viewer.scene.add(polyline, show_points=True, pointscolor=Color(0.0, 0.0, 1.0), linescolor=Color(1.0, 0.0, 0.0), lineswidth=5)
 
 viewer.show()

--- a/docs/examples/object/robot.py
+++ b/docs/examples/object/robot.py
@@ -14,7 +14,7 @@ model = RobotModel.from_urdf_file(github.load_urdf("irb6640.urdf"))
 model.load_geometry(github)
 
 
-robot_object: RobotModelObject = viewer.add(model, show_lines=False, configuration=model.random_configuration())  # type: ignore
+robot_object: RobotModelObject = viewer.scene.add(model, show_lines=False, configuration=model.random_configuration())  # type: ignore
 
 
 def rotate(value, robot_object: RobotModelObject, index: int):
@@ -36,7 +36,7 @@ for i, joint in enumerate(robot_object.configuration.joint_names):
     slider = viewer.layout.sidedock.add_element(slider)
 
 
-treeform = Treeform(viewer.tree, {"Name": ".name", "Object": ""})
+treeform = Treeform(viewer.scene.tree, {"Name": ".name", "Object": ""})
 
 viewer.layout.sidedock.add_element(treeform)
 

--- a/docs/examples/object/robot.py
+++ b/docs/examples/object/robot.py
@@ -24,15 +24,7 @@ def rotate(value, robot_object: RobotModelObject, index: int):
 
 
 for i, joint in enumerate(robot_object.configuration.joint_names):
-    slider = Slider(
-        rotate,
-        0,
-        -180,
-        180,
-        1,
-        joint,
-        kwargs={"robot_object": robot_object, "index": i},
-    )
+    slider = Slider(rotate, 0, -180, 180, 1, joint, robot_object=robot_object, index=i)
     slider = viewer.layout.sidedock.add_element(slider)
 
 

--- a/docs/examples/object/texts.py
+++ b/docs/examples/object/texts.py
@@ -5,12 +5,12 @@ from compas_viewer import Viewer
 viewer = Viewer()
 
 t = Tag("a", (0, 0, 0), height=50)
-viewer.add(t)
+viewer.scene.add(t)
 
 t = Tag("123", (3, 0, 0), height=50)
-viewer.add(t)
+viewer.scene.add(t)
 
 t = Tag("ABC", (3, 3, 0), height=20, absolute_height=True)
-viewer.add(t, color=(1, 0, 0))
+viewer.scene.add(t, color=(1, 0, 0))
 
 viewer.show()

--- a/docs/examples/object/vector.py
+++ b/docs/examples/object/vector.py
@@ -14,6 +14,6 @@ for i in range(0, 360, 20):
     for j in range(0, 180, 10):
         position = Vector(sin(radians(i)) * sin(radians(j)), cos(radians(i)) * sin(radians(j)), cos(radians(j)))
         vector = Vector(sin(radians(i)), cos(radians(i)), cos(radians(j)))
-        viewer.add(vector, anchor=position, linescolor=Color(random(), random(), random()))
+        viewer.scene.add(vector, anchor=position, linescolor=Color(random(), random(), random()))
 
 viewer.show()

--- a/src/compas_viewer/__main__.py
+++ b/src/compas_viewer/__main__.py
@@ -100,6 +100,6 @@ print("Check out our page for more tutorials, documentations and api references:
 
 
 for name, geometry in geometries.items():
-    viewer.add(item=geometry, name=name)
+    viewer.scene.add(item=geometry, name=name)
 
 viewer.show()

--- a/src/compas_viewer/actions/action.py
+++ b/src/compas_viewer/actions/action.py
@@ -54,6 +54,7 @@ class Action(QObject):
         super(Action, self).__init__()
         self.name = name
         self.viewer = viewer
+        self.scene = viewer.scene
         self.config = config
         self.key = self.config.key
         self.modifier = self.config.modifier

--- a/src/compas_viewer/actions/delete_selected.py
+++ b/src/compas_viewer/actions/delete_selected.py
@@ -5,8 +5,8 @@ class DeleteSelected(Action):
     """Permanently delete selected objects from the viewer and release the memory."""
 
     def pressed_action(self):
-        for obj in self.viewer.objects:
+        for obj in self.scene.objects:
             if obj.is_selected:
-                self.viewer.remove(obj)
+                self.scene.remove(obj)
                 del obj
         self.viewer.renderer.update()

--- a/src/compas_viewer/actions/info.py
+++ b/src/compas_viewer/actions/info.py
@@ -33,7 +33,7 @@ class SelectionInfo(Action):
     def pressed_action(self):
         info = "Selected objects: \n"
 
-        for i, obj in enumerate(self.viewer.objects):
+        for i, obj in enumerate(self.scene.objects):
             if obj.is_selected:
                 info += f"Object {i}: {obj} \n"
 

--- a/src/compas_viewer/actions/select_all.py
+++ b/src/compas_viewer/actions/select_all.py
@@ -5,6 +5,7 @@ class SelectAll(Action):
     """Select all objects."""
 
     def pressed_action(self):
-        for obj in self.viewer.objects:
-            obj.is_selected = True
+        for obj in self.scene.objects:
+            if obj.is_visible and not obj.is_locked:
+                obj.is_selected = True
         self.viewer.renderer.update()

--- a/src/compas_viewer/actions/zoom_selected.py
+++ b/src/compas_viewer/actions/zoom_selected.py
@@ -8,7 +8,7 @@ class ZoomSelected(Action):
     """Look at action."""
 
     def pressed_action(self):
-        selected_objs = [obj for obj in self.viewer.objects if obj.is_selected]
+        selected_objs = [obj for obj in self.scene.objects if obj.is_selected]
         extents = []
 
         for obj in selected_objs:

--- a/src/compas_viewer/components/renderer/selector.py
+++ b/src/compas_viewer/components/renderer/selector.py
@@ -61,6 +61,7 @@ class Selector(QObject):
         super().__init__()
         self.renderer = renderer
         self.viewer = renderer.viewer
+        self.scene = renderer.scene
         self.controller = renderer.viewer.controller
         self.selectioncolor = renderer.config.selector.selectioncolor
 
@@ -79,7 +80,7 @@ class Selector(QObject):
         """Select the object under the mouse cursor."""
 
         # Deselect all objects first
-        for _, obj in self.renderer.viewer.instance_colors.items():
+        for _, obj in self.renderer.scene.instance_colors.items():
             obj.is_selected = False
 
         x = self.controller.mouse.last_pos.x()
@@ -87,7 +88,7 @@ class Selector(QObject):
         instance_color = self.read_instance_color((x, y, x, y))
         unique_color = unique(instance_color, axis=0, return_counts=False)
 
-        selected_obj = self.renderer.viewer.instance_colors.get(tuple(unique_color[0]))  # type: ignore
+        selected_obj = self.renderer.scene.instance_colors.get(tuple(unique_color[0]))  # type: ignore
         if selected_obj:
             selected_obj.is_selected = True
 
@@ -99,7 +100,7 @@ class Selector(QObject):
         instance_color = self.read_instance_color((x, y, x, y))
         unique_color = unique(instance_color, axis=0, return_counts=False)
 
-        selected_obj = self.renderer.viewer.instance_colors.get(tuple(unique_color[0]))  # type: ignore
+        selected_obj = self.renderer.scene.instance_colors.get(tuple(unique_color[0]))  # type: ignore
         if selected_obj:
             selected_obj.is_selected = False
 
@@ -115,7 +116,7 @@ class Selector(QObject):
         instance_color = self.read_instance_color((x, y, x, y))
         unique_color = unique(instance_color, axis=0, return_counts=False)
 
-        selected_obj = self.renderer.viewer.instance_colors.get(tuple(unique_color[0]))  # type: ignore
+        selected_obj = self.renderer.scene.instance_colors.get(tuple(unique_color[0]))  # type: ignore
         if selected_obj:
             selected_obj.is_selected = True
 
@@ -123,7 +124,7 @@ class Selector(QObject):
         """Drag select the objects in the rectangle area."""
 
         # Deselect all objects first
-        for _, obj in self.renderer.viewer.instance_colors.items():
+        for _, obj in self.renderer.scene.instance_colors.items():
             obj.is_selected = False
 
         instance_color = self.read_instance_color(
@@ -137,7 +138,7 @@ class Selector(QObject):
         if len(unique_colors) == 0:
             return
 
-        for color, obj in self.renderer.viewer.instance_colors.items():
+        for color, obj in self.renderer.scene.instance_colors.items():
             if any(all(color == unique_colors, axis=1)):
                 obj.is_selected = True
                 continue
@@ -161,7 +162,7 @@ class Selector(QObject):
         if len(unique_colors) == 0:
             return
 
-        for color, obj in self.renderer.viewer.instance_colors.items():
+        for color, obj in self.renderer.scene.instance_colors.items():
             if any(all(color == unique_colors, axis=1)):
                 obj.is_selected = False
                 continue

--- a/src/compas_viewer/layout/slider.py
+++ b/src/compas_viewer/layout/slider.py
@@ -93,7 +93,7 @@ class Slider(QWidget):
         interval: int = 1,
         bgcolor: Optional[Color] = None,
         stretch: int = 0,
-        kwargs={},
+        **kwargs,
     ):
         if min_value > max_value or interval > max_value - min_value:
             raise ValueError("Slider parameters are invalid. ")

--- a/src/compas_viewer/layout/treeform.py
+++ b/src/compas_viewer/layout/treeform.py
@@ -51,7 +51,7 @@ class Treeform(QTreeWidget):
 
         for i in range(10):
             for j in range(10):
-                sp = viewer.add(Sphere(0.1, Frame([i, j, 0], [1, 0, 0], [0, 1, 0])), name=f"Sphere_{i}_{j}")
+                sp = viewer.scene.add(Sphere(0.1, Frame([i, j, 0], [1, 0, 0], [0, 1, 0])), name=f"Sphere_{i}_{j}")
 
         viewer.layout.sidedock.add_element(Treeform(viewer._tree, {"Name":".object.name", "Object":".object"}))
 

--- a/src/compas_viewer/scene/__init__.py
+++ b/src/compas_viewer/scene/__init__.py
@@ -5,7 +5,6 @@ This package provides scene object plugins for visualizing COMPAS objects in `co
 from typing import Union
 from compas.scene import register
 from compas.plugins import plugin
-from .sceneobject import ViewerSceneObject
 from compas.datastructures import Mesh
 from compas.datastructures import Graph
 from compas.geometry import (
@@ -28,10 +27,10 @@ from compas.geometry import (
     Geometry,
 )
 
-
+from .scene import ViewerScene  # noqa: F401
+from .sceneobject import ViewerSceneObject
 from .meshobject import MeshObject
 from .graphobject import GraphObject
-
 from .pointobject import PointObject
 from .lineobject import LineObject
 from .vectorobject import VectorObject

--- a/src/compas_viewer/scene/lineobject.py
+++ b/src/compas_viewer/scene/lineobject.py
@@ -14,6 +14,8 @@ class LineObject(ViewerSceneObject, GeometryObject):
     """
 
     def __init__(self, line: Line, **kwargs):
+        if kwargs["show_lines"] is None:
+            kwargs["show_lines"] = True
         super(LineObject, self).__init__(geometry=line, **kwargs)
 
     def _read_points_data(self) -> DataType:

--- a/src/compas_viewer/scene/pointobject.py
+++ b/src/compas_viewer/scene/pointobject.py
@@ -8,12 +8,21 @@ from .sceneobject import ViewerSceneObject
 class PointObject(ViewerSceneObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Point geometry.
 
+    Parameters
+    ----------
+    point : :class:`compas.geometry.Point`
+        The point geometry to display.
+    show_points : bool, optional
+        Whether to display the point in the viewer. Default is True.
+
     See Also
     --------
     :class:`compas.geometry.Point`
     """
 
     def __init__(self, point: Point, **kwargs):
+        if kwargs["show_points"] is None:
+            kwargs["show_points"] = True
         super(PointObject, self).__init__(geometry=point, **kwargs)
         self.geometry: Point
 

--- a/src/compas_viewer/scene/scene.py
+++ b/src/compas_viewer/scene/scene.py
@@ -1,0 +1,169 @@
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Optional
+from typing import Union
+
+from compas.colors import Color
+from compas.data import Data
+from compas.scene import Scene
+
+from compas_viewer.configurations import SceneConfig
+from compas_viewer.utilities import instance_colors_generator
+
+from .sceneobject import ViewerSceneObject
+
+if TYPE_CHECKING:
+    from compas_viewer import Viewer
+
+
+class ViewerScene(Scene):
+    """The ViewerScene class is a wrapper for the compas.Scene class,
+    providing additional functionality for the viewer.
+
+    Parameters
+    ----------
+    viewer : :class:`compas_viewer.Viewer`
+        The viewer object.
+    config : :class:`compas_viewer.configurations.scene_config.SceneConfig`
+        The configuration object for the scene.
+    name : str, optional
+        The name of the scene.
+
+    See Also
+    --------
+    :class:`compas.scene.Scene`
+    """
+
+    def __new__(cls, *args, **kwargs):
+        instance = super(ViewerScene, cls).__new__(cls)
+        Scene.viewerinstance = instance  # type: ignore
+        return instance
+
+    def __init__(self, viewer: "Viewer", config: SceneConfig, name=None):
+        super(ViewerScene, self).__init__(name=name)
+        self.viewer = viewer
+        self.config = config
+
+        #  Primitive
+        self.objects: list[ViewerSceneObject]
+
+        #  Selection
+        self.instance_colors: dict[tuple[int, int, int], ViewerSceneObject] = {}
+        self._instance_colors_generator = instance_colors_generator()
+
+    def add(
+        self,
+        item: Data,
+        parent: Optional[ViewerSceneObject] = None,
+        is_selected: bool = False,
+        is_locked: bool = False,
+        is_visible: bool = True,
+        show_points: Optional[bool] = None,
+        show_lines: Optional[bool] = None,
+        show_faces: Optional[bool] = None,
+        pointscolor: Optional[Union[Color, dict[Any, Color]]] = None,
+        linescolor: Optional[Union[Color, dict[Any, Color]]] = None,
+        facescolor: Optional[Union[Color, dict[Any, Color]]] = None,
+        lineswidth: Optional[float] = None,
+        pointssize: Optional[float] = None,
+        opacity: Optional[float] = None,
+        hide_coplanaredges: Optional[bool] = None,
+        use_vertexcolors: Optional[bool] = None,
+        **kwargs
+    ) -> ViewerSceneObject:
+        """
+        Add an item to the scene.
+        This function is inherent from :class:`compas.scene.Scene` with additional functionalities.
+
+        Parameters
+        ----------
+        item : Union[:class:`compas.geometry.Geometry`, :class:`compas.datastructures.Mesh`]
+            The geometry to add to the scene.
+        parent : :class:`compas_viewer.scene.ViewerSceneObject`, optional
+            The parent of the item.
+        is_selected : bool, optional
+            Whether the object is selected.
+            Default to False.
+        is_locked : bool, optional
+            Whether the object is locked (not selectable).
+            Default to False.
+        is_visible : bool, optional
+            Whether to show object.
+            Default to True.
+        show_points : bool, optional
+            Whether to show points/vertices of the object.
+            It will override the value in the scene config file.
+        show_lines : bool, optional
+            Whether to show lines/edges of the object.
+            It will override the value in the scene config file.
+        show_faces : bool, optional
+            Whether to show faces of the object.
+            It will override the value in the scene config file.
+        pointscolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
+            The color or the dict of colors of the points.
+            It will override the value in the scene config file.
+        linescolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
+            The color or the dict of colors of the lines.
+            It will override the value in the scene config file.
+        facescolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
+            The color or the dict of colors the faces.
+            It will override the value in the scene config file.
+        lineswidth : float, optional
+            The line width to be drawn on screen
+            It will override the value in the scene config file.
+        pointssize : float, optional
+            The point size to be drawn on screen
+            It will override the value in the scene config file.
+        opacity : float, optional
+            The opacity of the object.
+            It will override the value in the scene config file.
+        hide_coplanaredges : bool, optional
+            Whether to hide the coplanar edges of the mesh.
+            It will override the value in the scene config file.
+        use_vertexcolors : bool, optional
+            Whether to use vertex color.
+            It will override the value in the scene config file.
+        **kwargs : dict, optional
+            The other possible parameters to be passed to the object.
+
+        Returns
+        -------
+        :class:`compas_viewer.scene.ViewerSceneObject`
+            The scene object.
+        """
+
+        sceneobject: ViewerSceneObject = super(ViewerScene, self).add(  # type: ignore
+            item=item,
+            parent=parent,
+            viewer=self.viewer,
+            is_selected=is_selected,
+            is_visible=is_visible,
+            is_locked=is_locked,
+            show_points=show_points,
+            show_lines=show_lines,
+            show_faces=show_faces,
+            pointscolor=pointscolor,
+            linescolor=linescolor,
+            facescolor=facescolor,
+            lineswidth=lineswidth,
+            pointssize=pointssize,
+            opacity=opacity,
+            hide_coplanaredges=hide_coplanaredges,
+            use_vertexcolors=use_vertexcolors,
+            config=self.config,
+            **kwargs
+        )
+
+        if not is_locked:
+            self.instance_colors[sceneobject.instance_color.rgb255] = sceneobject
+
+        return sceneobject
+
+    def clear(self, guids: Optional[Union[list[str], list[ViewerSceneObject]]] = None):
+        """Clear the scene."""
+        if guids is None:
+            guids = self.objects
+
+        for obj in guids:
+            self.remove(obj)
+            del obj

--- a/src/compas_viewer/viewer.py
+++ b/src/compas_viewer/viewer.py
@@ -140,6 +140,24 @@ class Viewer:
         self.frame_count: int = 0
 
     # ==========================================================================
+    # Scene
+    # ==========================================================================
+
+    def add(self, item, **kwargs):
+        """
+        Add an item to the scene.
+        This is a compatibility function for the old version of the viewer.
+        While :func:`compas_viewer.scene.ViewerScene.add` is the recommended way to add an item to the scene.
+
+        Returns
+        -------
+        :class:`compas_viewer.scene.sceneobject.ViewerSceneObject`
+            The scene object.
+        """
+
+        return self.scene.add(item, **kwargs)
+
+    # ==========================================================================
     # Runtime
     # ==========================================================================
 

--- a/src/compas_viewer/viewer.py
+++ b/src/compas_viewer/viewer.py
@@ -1,15 +1,9 @@
 import sys
 from pathlib import Path
-from typing import Any
 from typing import Callable
 from typing import Literal
 from typing import Optional
-from typing import Union
 
-from compas.colors import Color
-from compas.data import Data
-from compas.geometry import Frame
-from compas.scene import Scene
 from PySide6.QtCore import QCoreApplication
 from PySide6.QtWidgets import QApplication
 from PySide6.QtWidgets import QMainWindow
@@ -24,15 +18,14 @@ from compas_viewer.configurations import RendererConfig
 from compas_viewer.configurations import SceneConfig
 from compas_viewer.controller import Controller
 from compas_viewer.layout import Layout
-from compas_viewer.scene import FrameObject
-from compas_viewer.scene import ViewerSceneObject
 from compas_viewer.utilities import Timer
-from compas_viewer.utilities import instance_colors_generator
+
+from .scene import ViewerScene as Scene
 
 
-class Viewer(Scene):
+class Viewer:
     """
-    The Viewer class is the main entry of `compas_viewer`. It organizes the scene and create the GUI application.
+    The Viewer class is the main entry of the viewer. It contains the scene and create the GUI application.
 
     Parameters
     ----------
@@ -56,6 +49,8 @@ class Viewer(Scene):
 
     Attributes
     ----------
+    scene : :class:`compas_viewer.scene.ViewerScene`
+        The scene of the viewer.
     render : :class:`compas_viewer.components.render.Render`
         The render component of the viewer.
     controller : :class:`compas_viewer.controller.Controller`
@@ -79,11 +74,6 @@ class Viewer(Scene):
         from compas_viewer import Viewer
         viewer = Viewer()
         viewer.show()
-
-    See Also
-    --------
-    :class:`compas.scene.Scene`
-
     """
 
     def __init__(
@@ -97,7 +87,7 @@ class Viewer(Scene):
         show_grid: Optional[bool] = None,
         configpath: Optional[str] = None,
     ):
-        super(Viewer, self).__init__()
+
         self.started = False
 
         # Custom or default config
@@ -132,24 +122,13 @@ class Viewer(Scene):
         self.app = QCoreApplication.instance() or QApplication(sys.argv)
         self.window = QMainWindow()
 
+        # Scene
+        self.scene = Scene(self, config=self.scene_config)
+
         # Controller
         self.controller = Controller(self, self.controller_config)
 
-        #  Selection
-        self.instance_colors: dict[tuple[int, int, int], ViewerSceneObject] = {}
-        self._instance_colors_generator = instance_colors_generator()
-
         # Render
-        self.grid = FrameObject(
-            Frame.worldXY(),
-            framesize=self.renderer_config.gridsize,
-            show_framez=self.renderer_config.show_gridz,
-            viewer=self,
-            is_selected=False,
-            is_locked=True,
-            is_visible=True,
-            config=self.scene_config,
-        )
         self.renderer = Renderer(self, self.renderer_config)
 
         # Layout
@@ -159,14 +138,6 @@ class Viewer(Scene):
         # `on` function
         self.timer: Timer
         self.frame_count: int = 0
-
-        #  Primitive
-        self.objects: list[ViewerSceneObject]
-
-    def __new__(cls, *args, **kwargs):
-        instance = super(Viewer, cls).__new__(cls)
-        Scene.viewerinstance = instance  # type: ignore
-        return instance
 
     # ==========================================================================
     # Runtime
@@ -238,117 +209,6 @@ class Viewer(Scene):
         return outer
 
     # ==========================================================================
-    # Scene
-    # ==========================================================================
-
-    def add(
-        self,
-        item: Data,
-        parent: Optional[ViewerSceneObject] = None,
-        is_selected: bool = False,
-        is_locked: bool = False,
-        is_visible: bool = True,
-        show_points: Optional[bool] = None,
-        show_lines: Optional[bool] = None,
-        show_faces: Optional[bool] = None,
-        pointscolor: Optional[Union[Color, dict[Any, Color]]] = None,
-        linescolor: Optional[Union[Color, dict[Any, Color]]] = None,
-        facescolor: Optional[Union[Color, dict[Any, Color]]] = None,
-        lineswidth: Optional[float] = None,
-        pointssize: Optional[float] = None,
-        opacity: Optional[float] = None,
-        hide_coplanaredges: Optional[bool] = None,
-        use_vertexcolors: Optional[bool] = None,
-        **kwargs
-    ) -> ViewerSceneObject:
-        """
-        Add an item to the scene.
-        This function is inherent from :class:`compas.scene.Scene` with additional functionalities.
-
-        Parameters
-        ----------
-        item : Union[:class:`compas.geometry.Geometry`, :class:`compas.datastructures.Mesh`]
-            The geometry to add to the scene.
-        parent : :class:`compas_viewer.scene.ViewerSceneObject`, optional
-            The parent of the item.
-        is_selected : bool, optional
-            Whether the object is selected.
-            Default to False.
-        is_locked : bool, optional
-            Whether the object is locked (not selectable).
-            Default to False.
-        is_visible : bool, optional
-            Whether to show object.
-            Default to True.
-        show_points : bool, optional
-            Whether to show points/vertices of the object.
-            It will override the value in the scene config file.
-        show_lines : bool, optional
-            Whether to show lines/edges of the object.
-            It will override the value in the scene config file.
-        show_faces : bool, optional
-            Whether to show faces of the object.
-            It will override the value in the scene config file.
-        pointscolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
-            The color or the dict of colors of the points.
-            It will override the value in the scene config file.
-        linescolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
-            The color or the dict of colors of the lines.
-            It will override the value in the scene config file.
-        facescolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
-            The color or the dict of colors the faces.
-            It will override the value in the scene config file.
-        lineswidth : float, optional
-            The line width to be drawn on screen
-            It will override the value in the scene config file.
-        pointssize : float, optional
-            The point size to be drawn on screen
-            It will override the value in the scene config file.
-        opacity : float, optional
-            The opacity of the object.
-            It will override the value in the scene config file.
-        hide_coplanaredges : bool, optional
-            Whether to hide the coplanar edges of the mesh.
-            It will override the value in the scene config file.
-        use_vertexcolors : bool, optional
-            Whether to use vertex color.
-            It will override the value in the scene config file.
-        **kwargs : dict, optional
-            The other possible parameters to be passed to the object.
-
-        Returns
-        -------
-        :class:`compas.scene.SceneObject`
-            The scene object.
-        """
-
-        sceneobject: ViewerSceneObject = super(Viewer, self).add(  # type: ignore
-            item=item,
-            parent=parent,
-            viewer=self,
-            is_selected=is_selected,
-            is_visible=is_visible,
-            is_locked=is_locked,
-            show_points=show_points,
-            show_lines=show_lines,
-            show_faces=show_faces,
-            pointscolor=pointscolor,
-            linescolor=linescolor,
-            facescolor=facescolor,
-            lineswidth=lineswidth,
-            pointssize=pointssize,
-            opacity=opacity,
-            hide_coplanaredges=hide_coplanaredges,
-            use_vertexcolors=use_vertexcolors,
-            config=self.scene_config,
-            **kwargs
-        )
-
-        self.instance_colors[sceneobject.instance_color.rgb255] = sceneobject
-
-        return sceneobject
-
-    # ==========================================================================
     # Action
     # ==========================================================================
 
@@ -391,7 +251,7 @@ class Viewer(Scene):
             from compas.geometry import Transformation
             from compas_viewer import Viewer
             viewer = Viewer()
-            faces = viewer.add(Mesh.from_obj(compas.get("faces.obj")))
+            faces = viewer.scene.add(Mesh.from_obj(compas.get("faces.obj")))
             faces.transformation = Transformation()
             def pressed_action():
                 faces.transformation *= Scale.from_factors([1.1, 1.1, 1.1], Frame.worldXY())
@@ -421,12 +281,3 @@ class Viewer(Scene):
         self.controller.actions[name] = action
 
         return action
-
-    def clear(self, guids: Optional[Union[list[str], list[ViewerSceneObject]]] = None):
-        """Clear the scene."""
-        if guids is None:
-            guids = self.objects
-
-        for obj in guids:
-            self.remove(obj)
-            del obj


### PR DESCRIPTION
- Please prioritize #78 and #75 these two small PRs before reviewing this one.
- Please publish a **Major** release after passing this PR - this is a relative major architecture change.

## Major Changes
- resolve #28 , separate `Viewer` and `Scene`, `Scene` is the attribute of `Viewer`. As communicated with @tomvanmele  and @Licini . `Viewer` becomes a pure CAD environment and the `Scene` manages the objects.
- Now adding objects should be like `viewer.scene.add(object)`.

## Minor Changes
- Some small fix of the displaying.

## The validation is tested by manually running through all the example files.



