### PR TITLE
Refactor Scene Objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `RobotModelObject` and its example in the documentation.
 
 ### Changed
-
+* Renamed `surfaces` into `viewmesh` in every `ViewerGeometryObject`.
+* Renamed `scene.json` to `viewer.json` and `scene_config` to `viewer_config`.
 * Unify color naming. variables that control the colors of geometries are `surfacecolor`, `linecolor`,`pointcolor`, yet variables that control the colors of meshes are `facecolor`, `edgecolor`, `vertexcolor`.
 * Added `ViewerGeometryObject` as the abstract class for all the geometry objects. Other specific geometry objects are inherited from this class.
 * Changed `DataType` into `ShaderDataType`. Resolve to [#46](https://github.com/compas-dev/compas_viewer/issues/46).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* Added `RobotModelObject` and its example in the documentation.
+
+-   Added `RobotModelObject` and its example in the documentation.
 
 ### Changed
 
-
-* Added `ViewerScene` as an attribute of the `Viewer` class. resolve [#28](https://github.com/compas-dev/compas_viewer/issues/28).
-* Bug fix of [#73](https://github.com/compas-dev/compas_viewer/issues/73).
-* Improved argument passing mechanism in the `Slider` class. Close [#76](https://github.com/compas-dev/compas_viewer/issues/76).
-* Documentation images and code correction.
-* Improved typing hints of `CollectionObject`.
-* Changed to the point object is `show_points = True` by default. Refer to [#73](https://github.com/compas-dev/compas_viewer/issues/73).
-* Changed from `super(__t, __obj)` to `super()` as the new version.
+-   Unify color naming. variables that control the colors of geometries are `surfacecolor`, `linecolor`,`pointcolor`, yet variables that control the colors of meshes are `facecolor`, `edgecolor`, `vertexcolor`.
+-   Added `ViewerGeometryObject` as the abstract class for all the geometry objects. Other specific geometry objects are inherited from this class.
+-   Changed `DataType` into `ShaderDataType`. Resolve to [#46](https://github.com/compas-dev/compas_viewer/issues/46).
+-   Added `ViewerScene` as an attribute of the `Viewer` class. resolve [#28](https://github.com/compas-dev/compas_viewer/issues/28).
+-   Bug fix of [#73](https://github.com/compas-dev/compas_viewer/issues/73).
+-   Improved argument passing mechanism in the `Slider` class. Close [#76](https://github.com/compas-dev/compas_viewer/issues/76).
+-   Documentation images and code correction.
+-   Improved typing hints of `CollectionObject`.
+-   Changed to the point object is `show_points = True` by default. Refer to [#73](https://github.com/compas-dev/compas_viewer/issues/73).
+-   Changed from `super(__t, __obj)` to `super()` as the new version.
 
 ### Removed
-
 
 ## [1.0.1] 2024-02-01
 
@@ -30,93 +32,94 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Fixed the bug to include `data` folder in the package.
+-   Fixed the bug to include `data` folder in the package.
 
 ### Removed
-
 
 ## [1.0.0] 2024-02-01
 
 ### Added
-* Added examples in the doc.
-* Added `Treeform`.
-* Added basic layout elements: `MenubarLayout`, `ToolbarLayout`, `StatusbarLayout`,`SidedockLayout`.
-* Added Actions: delete_selected, camera_info, selection_info.
-* Added basic buildup of `Layout`'s configurations. The .json template and the configuration classes.
-* `Layout` class basic buildup: `Layout`, `ViewportLayout`, `WindowLayout`.
-* Added terminal activation of the viewer.
-* Added `PyOpenGL_accelerate` dependency.
-* Added repo images. 
-* Added `installation` documentation.
-* Added documentations: index, api, etc. Mockups style is improved.
-* Added `DeleteSelected` action class.
-* Added `DataType` as the data type template for generating the buffer.
-* Added `NetworkObject` for the scene objects.
-* Added `compas_viewer.scene.ViewerSceneObject.LINEWIDTH_SELECTION_INCREMENTAL` to enhance line width for selection only.
-* Added `BRepObject`, `CapsuleObject`, `ConeObject`, `CylinderObject`, `PlaneObject`, `SphereObject`, `EllipseObject`, `TorusObject`, `PolygonObject`, `PolylineObject`, `BoxObject`. The geometric resolution is handled by the `compas_viewer.scene.ViewerSceneObject.LINEARDEFLECTION`.
-* Added `VectorObject` for the scene objects with mesh-based display for better visual effect.
-* Added "instance" render mode for debugging and geometric analysis.
-* Added contents in the `README.md`.
-* Added full support for selection: drag_selection, drag_deselection, multiselect, deselect, select.
-* Added `SelectAll` action class.
-* Added `LookAt` action class.
-* Added `compas_viewer.Viewer.add_action` for adding actions to the viewer.
-* Added `Signal` structure for the `Action` class.
-* Added complete key, mouse and modifier support from `PySide6`.
-* Added `ZoomSelected` and `GLInfo` classes as template action classes.
-* Added `Action` class.
-* Added `Controller` class for the controller.
-* Added `Grid` and `GridObject` for the scene objects.
-* Added `TagObject`, `LineObject` and `PointObject` for the scene objects.
-* Added test files for configurations.
-* Added doc build, and many doc-building syntax fixes.
-* Added `scene.json` for storing the scene configurations. Mostly store the default appearance features of the objects.
-* `compas` recognizes `compas_viewer` context, and map the according `compas_viewer` objects to the `compas` objects.
-* Added two main scene objects: `ViewerSceneObject` and `MeshObject`. `BufferObject` no longer exists but replaced by `ViewerSceneObject`.
-* Added `add` function in the `Viewer` class for adding objects to the scene, which is also the entry for imputing user-defined attributes.
-* Added and formatted `Shader` and `Camera`.
-* Added a `RenderConfig` for configuring the Render object.
-* Added the `shaders` and the `Shader` class in the shader folder.
-* Created the `Camera`, `metrics` and `gl` functions and classes (most copied from the view2).
-* Adjustment of the `ControllerConfig` and `ViewerConfig``.
-* Adjustment of the `Viewer`.
-* Basic `Viewer` buildup with the widgets.
-* Configurations: `controller_config` and `viewer_config`
-* Code and File structure diagrams.
-* Added `NetworkObject`.
+
+-   Added examples in the doc.
+-   Added `Treeform`.
+-   Added basic layout elements: `MenubarLayout`, `ToolbarLayout`, `StatusbarLayout`,`SidedockLayout`.
+-   Added Actions: delete_selected, camera_info, selection_info.
+-   Added basic buildup of `Layout`'s configurations. The .json template and the configuration classes.
+-   `Layout` class basic buildup: `Layout`, `ViewportLayout`, `WindowLayout`.
+-   Added terminal activation of the viewer.
+-   Added `PyOpenGL_accelerate` dependency.
+-   Added repo images.
+-   Added `installation` documentation.
+-   Added documentations: index, api, etc. Mockups style is improved.
+-   Added `DeleteSelected` action class.
+-   Added `ShaderDataType` as the data type template for generating the buffer.
+-   Added `NetworkObject` for the scene objects.
+-   Added `compas_viewer.scene.ViewerSceneObject.LINEWIDTH_SELECTION_INCREMENTAL` to enhance line width for selection only.
+-   Added `BRepObject`, `CapsuleObject`, `ConeObject`, `CylinderObject`, `PlaneObject`, `SphereObject`, `EllipseObject`, `TorusObject`, `PolygonObject`, `PolylineObject`, `BoxObject`. The geometric resolution is handled by the `compas_viewer.scene.ViewerSceneObject.LINEARDEFLECTION`.
+-   Added `VectorObject` for the scene objects with mesh-based display for better visual effect.
+-   Added "instance" render mode for debugging and geometric analysis.
+-   Added contents in the `README.md`.
+-   Added full support for selection: drag_selection, drag_deselection, multiselect, deselect, select.
+-   Added `SelectAll` action class.
+-   Added `LookAt` action class.
+-   Added `compas_viewer.Viewer.add_action` for adding actions to the viewer.
+-   Added `Signal` structure for the `Action` class.
+-   Added complete key, mouse and modifier support from `PySide6`.
+-   Added `ZoomSelected` and `GLInfo` classes as template action classes.
+-   Added `Action` class.
+-   Added `Controller` class for the controller.
+-   Added `Grid` and `GridObject` for the scene objects.
+-   Added `TagObject`, `LineObject` and `PointObject` for the scene objects.
+-   Added test files for configurations.
+-   Added doc build, and many doc-building syntax fixes.
+-   Added `scene.json` for storing the scene configurations. Mostly store the default appearance features of the objects.
+-   `compas` recognizes `compas_viewer` context, and map the according `compas_viewer` objects to the `compas` objects.
+-   Added two main scene objects: `ViewerSceneObject` and `MeshObject`. `BufferObject` no longer exists but replaced by `ViewerSceneObject`.
+-   Added `add` function in the `Viewer` class for adding objects to the scene, which is also the entry for imputing user-defined attributes.
+-   Added and formatted `Shader` and `Camera`.
+-   Added a `RenderConfig` for configuring the Render object.
+-   Added the `shaders` and the `Shader` class in the shader folder.
+-   Created the `Camera`, `metrics` and `gl` functions and classes (most copied from the view2).
+-   Adjustment of the `ControllerConfig` and `ViewerConfig``.
+-   Adjustment of the `Viewer`.
+-   Basic `Viewer` buildup with the widgets.
+-   Configurations: `controller_config` and `viewer_config`
+-   Code and File structure diagrams.
+-   Added `NetworkObject`.
 
 ### Changed
 
-* Fixed [#64](https://github.com/compas-dev/compas_viewer/issues/64).
-* Patch github actions.
-* Fix [#63](https://github.com/compas-dev/compas_viewer/issues/63). 
-* Updated the configuration architecture.
-* Updated the `delete_selected` action.
-* Renamed `NetworkObject` to `GraphObject`. See commit: https://github.com/compas-dev/compas/commit/7f7098c11a1a4c3c8c0b527c8f610d10adbba1a6#diff-4e906e478c68aaee46648b7323ed68106084e647748b4e0bcb5fd440c3e162fb.
-* Updated the `Slider`.
-* Documentation improved.
-* `Timer` is moved to utilities.
-* Updated `BRepObject` to connect the latest OCC package, close [#48](https://github.com/compas-dev/compas_viewer/issues/48).
-* Fixed opacity bug in shaded mode.
-* Fixed main page link.
-* Fixed issue [#17](https://github.com/compas-dev/compas_viewer/issues/17) and avoid using `vertex_xyz`.
-* Update the dependency of `compas`.
-* The `Index` page.
-* Typing hints improved, now `compas_viewer` only support Python 3.9+.
-* Introduce decorator @lru_cache() to reduce duplicate calculations. 
-* Refactored the `Selector` and the instance_map structure, the main frame rate is higher and selection action is faster.
-* Fixed the bug of the `Selector`, drag selection is now more accurate.
-* More performative instance map and QObject-based selection architecture.
-* Naming of the keys, mouses, and modifiers are changed. The key string which is the same as what it was called in the PySide6.QtCore.Qt, with lowercases and with prefix&underscores removed.
-* `Grid` object inherits from `compas.data.Data`.
-* Update the compatibility of the `ViewerSceneObject` to the core `SceneObject`.
-* Refactored the `ControllerConfig`.
-* Fix Qt package of `PySide6`.
-* Moved `gl` from `render` folder to the `utilities` folder.
-* All color representations are now in `compas.colors.Color`.
-* Reduce the `numpy.array` representation. Mostly use `list` instead for clarity.
-* Comments improved and better type hints.
+-   Fixed [#64](https://github.com/compas-dev/compas_viewer/issues/64).
+-   Patch github actions.
+-   Fix [#63](https://github.com/compas-dev/compas_viewer/issues/63).
+-   Updated the configuration architecture.
+-   Updated the `delete_selected` action.
+-   Renamed `NetworkObject` to `GraphObject`. See commit: https://github.com/compas-dev/compas/commit/7f7098c11a1a4c3c8c0b527c8f610d10adbba1a6#diff-4e906e478c68aaee46648b7323ed68106084e647748b4e0bcb5fd440c3e162fb.
+-   Updated the `Slider`.
+-   Documentation improved.
+-   `Timer` is moved to utilities.
+-   Updated `BRepObject` to connect the latest OCC package, close [#48](https://github.com/compas-dev/compas_viewer/issues/48).
+-   Fixed opacity bug in shaded mode.
+-   Fixed main page link.
+-   Fixed issue [#17](https://github.com/compas-dev/compas_viewer/issues/17) and avoid using `vertex_xyz`.
+-   Update the dependency of `compas`.
+-   The `Index` page.
+-   Typing hints improved, now `compas_viewer` only support Python 3.9+.
+-   Introduce decorator @lru_cache() to reduce duplicate calculations.
+-   Refactored the `Selector` and the instance_map structure, the main frame rate is higher and selection action is faster.
+-   Fixed the bug of the `Selector`, drag selection is now more accurate.
+-   More performative instance map and QObject-based selection architecture.
+-   Naming of the keys, mouses, and modifiers are changed. The key string which is the same as what it was called in the PySide6.QtCore.Qt, with lowercases and with prefix&underscores removed.
+-   `Grid` object inherits from `compas.data.Data`.
+-   Update the compatibility of the `ViewerSceneObject` to the core `SceneObject`.
+-   Refactored the `ControllerConfig`.
+-   Fix Qt package of `PySide6`.
+-   Moved `gl` from `render` folder to the `utilities` folder.
+-   All color representations are now in `compas.colors.Color`.
+-   Reduce the `numpy.array` representation. Mostly use `list` instead for clarity.
+-   Comments improved and better type hints.
 
 ### Removed
-* Removed `self.objects` from the `Render` class.`
-* Replace the `Grid` and `GridObject` but by `FrameObject`, which also hooks the `Frame` in compas.
+
+-   Removed `self.objects` from the `Render` class.`
+-   Replace the `Grid` and `GridObject` but by `FrameObject`, which also hooks the `Frame` in compas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
--   Added `RobotModelObject` and its example in the documentation.
+* Added `RobotModelObject` and its example in the documentation.
 
 ### Changed
 
--   Unify color naming. variables that control the colors of geometries are `surfacecolor`, `linecolor`,`pointcolor`, yet variables that control the colors of meshes are `facecolor`, `edgecolor`, `vertexcolor`.
--   Added `ViewerGeometryObject` as the abstract class for all the geometry objects. Other specific geometry objects are inherited from this class.
--   Changed `DataType` into `ShaderDataType`. Resolve to [#46](https://github.com/compas-dev/compas_viewer/issues/46).
--   Added `ViewerScene` as an attribute of the `Viewer` class. resolve [#28](https://github.com/compas-dev/compas_viewer/issues/28).
--   Bug fix of [#73](https://github.com/compas-dev/compas_viewer/issues/73).
--   Improved argument passing mechanism in the `Slider` class. Close [#76](https://github.com/compas-dev/compas_viewer/issues/76).
--   Documentation images and code correction.
--   Improved typing hints of `CollectionObject`.
--   Changed to the point object is `show_points = True` by default. Refer to [#73](https://github.com/compas-dev/compas_viewer/issues/73).
--   Changed from `super(__t, __obj)` to `super()` as the new version.
+* Unify color naming. variables that control the colors of geometries are `surfacecolor`, `linecolor`,`pointcolor`, yet variables that control the colors of meshes are `facecolor`, `edgecolor`, `vertexcolor`.
+* Added `ViewerGeometryObject` as the abstract class for all the geometry objects. Other specific geometry objects are inherited from this class.
+* Changed `DataType` into `ShaderDataType`. Resolve to [#46](https://github.com/compas-dev/compas_viewer/issues/46).
+* Added `ViewerScene` as an attribute of the `Viewer` class. resolve [#28](https://github.com/compas-dev/compas_viewer/issues/28).
+* Bug fix of [#73](https://github.com/compas-dev/compas_viewer/issues/73).
+* Improved argument passing mechanism in the `Slider` class. Close [#76](https://github.com/compas-dev/compas_viewer/issues/76).
+* Documentation images and code correction.
+* Improved typing hints of `CollectionObject`.
+* Changed to the point object is `show_points = True` by default. Refer to [#73](https://github.com/compas-dev/compas_viewer/issues/73).
+* Changed from `super(__t, __obj)` to `super()` as the new version.
 
 ### Removed
+
 
 ## [1.0.1] 2024-02-01
 
@@ -32,94 +32,93 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Fixed the bug to include `data` folder in the package.
+* Fixed the bug to include `data` folder in the package.
 
 ### Removed
+
 
 ## [1.0.0] 2024-02-01
 
 ### Added
-
--   Added examples in the doc.
--   Added `Treeform`.
--   Added basic layout elements: `MenubarLayout`, `ToolbarLayout`, `StatusbarLayout`,`SidedockLayout`.
--   Added Actions: delete_selected, camera_info, selection_info.
--   Added basic buildup of `Layout`'s configurations. The .json template and the configuration classes.
--   `Layout` class basic buildup: `Layout`, `ViewportLayout`, `WindowLayout`.
--   Added terminal activation of the viewer.
--   Added `PyOpenGL_accelerate` dependency.
--   Added repo images.
--   Added `installation` documentation.
--   Added documentations: index, api, etc. Mockups style is improved.
--   Added `DeleteSelected` action class.
--   Added `ShaderDataType` as the data type template for generating the buffer.
--   Added `NetworkObject` for the scene objects.
--   Added `compas_viewer.scene.ViewerSceneObject.LINEWIDTH_SELECTION_INCREMENTAL` to enhance line width for selection only.
--   Added `BRepObject`, `CapsuleObject`, `ConeObject`, `CylinderObject`, `PlaneObject`, `SphereObject`, `EllipseObject`, `TorusObject`, `PolygonObject`, `PolylineObject`, `BoxObject`. The geometric resolution is handled by the `compas_viewer.scene.ViewerSceneObject.LINEARDEFLECTION`.
--   Added `VectorObject` for the scene objects with mesh-based display for better visual effect.
--   Added "instance" render mode for debugging and geometric analysis.
--   Added contents in the `README.md`.
--   Added full support for selection: drag_selection, drag_deselection, multiselect, deselect, select.
--   Added `SelectAll` action class.
--   Added `LookAt` action class.
--   Added `compas_viewer.Viewer.add_action` for adding actions to the viewer.
--   Added `Signal` structure for the `Action` class.
--   Added complete key, mouse and modifier support from `PySide6`.
--   Added `ZoomSelected` and `GLInfo` classes as template action classes.
--   Added `Action` class.
--   Added `Controller` class for the controller.
--   Added `Grid` and `GridObject` for the scene objects.
--   Added `TagObject`, `LineObject` and `PointObject` for the scene objects.
--   Added test files for configurations.
--   Added doc build, and many doc-building syntax fixes.
--   Added `scene.json` for storing the scene configurations. Mostly store the default appearance features of the objects.
--   `compas` recognizes `compas_viewer` context, and map the according `compas_viewer` objects to the `compas` objects.
--   Added two main scene objects: `ViewerSceneObject` and `MeshObject`. `BufferObject` no longer exists but replaced by `ViewerSceneObject`.
--   Added `add` function in the `Viewer` class for adding objects to the scene, which is also the entry for imputing user-defined attributes.
--   Added and formatted `Shader` and `Camera`.
--   Added a `RenderConfig` for configuring the Render object.
--   Added the `shaders` and the `Shader` class in the shader folder.
--   Created the `Camera`, `metrics` and `gl` functions and classes (most copied from the view2).
--   Adjustment of the `ControllerConfig` and `ViewerConfig``.
--   Adjustment of the `Viewer`.
--   Basic `Viewer` buildup with the widgets.
--   Configurations: `controller_config` and `viewer_config`
--   Code and File structure diagrams.
--   Added `NetworkObject`.
+* Added examples in the doc.
+* Added `Treeform`.
+* Added basic layout elements: `MenubarLayout`, `ToolbarLayout`, `StatusbarLayout`,`SidedockLayout`.
+* Added Actions: delete_selected, camera_info, selection_info.
+* Added basic buildup of `Layout`'s configurations. The .json template and the configuration classes.
+* `Layout` class basic buildup: `Layout`, `ViewportLayout`, `WindowLayout`.
+* Added terminal activation of the viewer.
+* Added `PyOpenGL_accelerate` dependency.
+* Added repo images. 
+* Added `installation` documentation.
+* Added documentations: index, api, etc. Mockups style is improved.
+* Added `DeleteSelected` action class.
+* Added `ShaderDataType` as the data type template for generating the buffer.
+* Added `NetworkObject` for the scene objects.
+* Added `compas_viewer.scene.ViewerSceneObject.LINEWIDTH_SELECTION_INCREMENTAL` to enhance line width for selection only.
+* Added `BRepObject`, `CapsuleObject`, `ConeObject`, `CylinderObject`, `PlaneObject`, `SphereObject`, `EllipseObject`, `TorusObject`, `PolygonObject`, `PolylineObject`, `BoxObject`. The geometric resolution is handled by the `compas_viewer.scene.ViewerSceneObject.LINEARDEFLECTION`.
+* Added `VectorObject` for the scene objects with mesh-based display for better visual effect.
+* Added "instance" render mode for debugging and geometric analysis.
+* Added contents in the `README.md`.
+* Added full support for selection: drag_selection, drag_deselection, multiselect, deselect, select.
+* Added `SelectAll` action class.
+* Added `LookAt` action class.
+* Added `compas_viewer.Viewer.add_action` for adding actions to the viewer.
+* Added `Signal` structure for the `Action` class.
+* Added complete key, mouse and modifier support from `PySide6`.
+* Added `ZoomSelected` and `GLInfo` classes as template action classes.
+* Added `Action` class.
+* Added `Controller` class for the controller.
+* Added `Grid` and `GridObject` for the scene objects.
+* Added `TagObject`, `LineObject` and `PointObject` for the scene objects.
+* Added test files for configurations.
+* Added doc build, and many doc-building syntax fixes.
+* Added `scene.json` for storing the scene configurations. Mostly store the default appearance features of the objects.
+* `compas` recognizes `compas_viewer` context, and map the according `compas_viewer` objects to the `compas` objects.
+* Added two main scene objects: `ViewerSceneObject` and `MeshObject`. `BufferObject` no longer exists but replaced by `ViewerSceneObject`.
+* Added `add` function in the `Viewer` class for adding objects to the scene, which is also the entry for imputing user-defined attributes.
+* Added and formatted `Shader` and `Camera`.
+* Added a `RenderConfig` for configuring the Render object.
+* Added the `shaders` and the `Shader` class in the shader folder.
+* Created the `Camera`, `metrics` and `gl` functions and classes (most copied from the view2).
+* Adjustment of the `ControllerConfig` and `ViewerConfig``.
+* Adjustment of the `Viewer`.
+* Basic `Viewer` buildup with the widgets.
+* Configurations: `controller_config` and `viewer_config`
+* Code and File structure diagrams.
+* Added `NetworkObject`.
 
 ### Changed
 
--   Fixed [#64](https://github.com/compas-dev/compas_viewer/issues/64).
--   Patch github actions.
--   Fix [#63](https://github.com/compas-dev/compas_viewer/issues/63).
--   Updated the configuration architecture.
--   Updated the `delete_selected` action.
--   Renamed `NetworkObject` to `GraphObject`. See commit: https://github.com/compas-dev/compas/commit/7f7098c11a1a4c3c8c0b527c8f610d10adbba1a6#diff-4e906e478c68aaee46648b7323ed68106084e647748b4e0bcb5fd440c3e162fb.
--   Updated the `Slider`.
--   Documentation improved.
--   `Timer` is moved to utilities.
--   Updated `BRepObject` to connect the latest OCC package, close [#48](https://github.com/compas-dev/compas_viewer/issues/48).
--   Fixed opacity bug in shaded mode.
--   Fixed main page link.
--   Fixed issue [#17](https://github.com/compas-dev/compas_viewer/issues/17) and avoid using `vertex_xyz`.
--   Update the dependency of `compas`.
--   The `Index` page.
--   Typing hints improved, now `compas_viewer` only support Python 3.9+.
--   Introduce decorator @lru_cache() to reduce duplicate calculations.
--   Refactored the `Selector` and the instance_map structure, the main frame rate is higher and selection action is faster.
--   Fixed the bug of the `Selector`, drag selection is now more accurate.
--   More performative instance map and QObject-based selection architecture.
--   Naming of the keys, mouses, and modifiers are changed. The key string which is the same as what it was called in the PySide6.QtCore.Qt, with lowercases and with prefix&underscores removed.
--   `Grid` object inherits from `compas.data.Data`.
--   Update the compatibility of the `ViewerSceneObject` to the core `SceneObject`.
--   Refactored the `ControllerConfig`.
--   Fix Qt package of `PySide6`.
--   Moved `gl` from `render` folder to the `utilities` folder.
--   All color representations are now in `compas.colors.Color`.
--   Reduce the `numpy.array` representation. Mostly use `list` instead for clarity.
--   Comments improved and better type hints.
+* Fixed [#64](https://github.com/compas-dev/compas_viewer/issues/64).
+* Patch github actions.
+* Fix [#63](https://github.com/compas-dev/compas_viewer/issues/63). 
+* Updated the configuration architecture.
+* Updated the `delete_selected` action.
+* Renamed `NetworkObject` to `GraphObject`. See commit: https://github.com/compas-dev/compas/commit/7f7098c11a1a4c3c8c0b527c8f610d10adbba1a6#diff-4e906e478c68aaee46648b7323ed68106084e647748b4e0bcb5fd440c3e162fb.
+* Updated the `Slider`.
+* Documentation improved.
+* `Timer` is moved to utilities.
+* Updated `BRepObject` to connect the latest OCC package, close [#48](https://github.com/compas-dev/compas_viewer/issues/48).
+* Fixed opacity bug in shaded mode.
+* Fixed main page link.
+* Fixed issue [#17](https://github.com/compas-dev/compas_viewer/issues/17) and avoid using `vertex_xyz`.
+* Update the dependency of `compas`.
+* The `Index` page.
+* Typing hints improved, now `compas_viewer` only support Python 3.9+.
+* Introduce decorator @lru_cache() to reduce duplicate calculations. 
+* Refactored the `Selector` and the instance_map structure, the main frame rate is higher and selection action is faster.
+* Fixed the bug of the `Selector`, drag selection is now more accurate.
+* More performative instance map and QObject-based selection architecture.
+* Naming of the keys, mouses, and modifiers are changed. The key string which is the same as what it was called in the PySide6.QtCore.Qt, with lowercases and with prefix&underscores removed.
+* `Grid` object inherits from `compas.data.Data`.
+* Update the compatibility of the `ViewerSceneObject` to the core `SceneObject`.
+* Refactored the `ControllerConfig`.
+* Fix Qt package of `PySide6`.
+* Moved `gl` from `render` folder to the `utilities` folder.
+* All color representations are now in `compas.colors.Color`.
+* Reduce the `numpy.array` representation. Mostly use `list` instead for clarity.
+* Comments improved and better type hints.
 
 ### Removed
-
--   Removed `self.objects` from the `Render` class.`
--   Replace the `Grid` and `GridObject` but by `FrameObject`, which also hooks the `Frame` in compas.
+* Removed `self.objects` from the `Render` class.`
+* Replace the `Grid` and `GridObject` but by `FrameObject`, which also hooks the `Frame` in compas.

--- a/src/compas_viewer/components/renderer/renderer.py
+++ b/src/compas_viewer/components/renderer/renderer.py
@@ -25,7 +25,7 @@ from .shaders import Shader
 if TYPE_CHECKING:
     # https://peps.python.org/pep-0484/#runtime-or-type-checking
     from compas_viewer import Viewer
-    from compas_viewer.scene.frameobject import FrameObject
+    from compas_viewer.scene.gridobject import GridObject
     from compas_viewer.scene.meshobject import MeshObject
 
 
@@ -65,7 +65,7 @@ class Renderer(QOpenGLWidget):
 
         self.camera = Camera(self)
         self.selector = Selector(self)
-        self.grid: "FrameObject"
+        self.grid: "GridObject"
 
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
 
@@ -362,8 +362,8 @@ class Renderer(QOpenGLWidget):
         """Initialize the renderer."""
 
         # Init the grid
-        self.grid: FrameObject = self.scene.add(  # type: ignore
-            item=Frame.worldXY(),
+        self.grid: GridObject = self.scene.add(  # type: ignore
+            Frame.worldXY(),
             framesize=self.config.gridsize,
             show_framez=self.config.show_gridz,
             is_selected=False,

--- a/src/compas_viewer/components/renderer/renderer.py
+++ b/src/compas_viewer/components/renderer/renderer.py
@@ -362,15 +362,15 @@ class Renderer(QOpenGLWidget):
         """Initialize the renderer."""
 
         # Init the grid
-        self.grid = self.scene.add(  # type: ignore
-            Frame.worldXY(),
+        self.grid: FrameObject = self.scene.add(  # type: ignore
+            item=Frame.worldXY(),
             framesize=self.config.gridsize,
             show_framez=self.config.show_gridz,
             is_selected=False,
             is_locked=True,
             is_visible=self.config.show_grid,
         )
-        self.grid.init()
+        self.grid.init()  # type: ignore
 
         # Init the buffers
         for obj in self.scene.objects:

--- a/src/compas_viewer/components/renderer/shaders/model.frag
+++ b/src/compas_viewer/components/renderer/shaders/model.frag
@@ -9,32 +9,25 @@ uniform bool is_lighted;
 uniform bool is_selected;
 uniform vec3 selection_color;
 uniform int element_type;
-uniform vec3 single_color;
-uniform bool use_single_color;
-
 
 void main()
-{   
-    float alpha = opacity * object_opacity;
+{
+    float alpha=opacity*object_opacity;
     vec3 color;
-    if (use_single_color){
-        color = single_color;
-    }else{
-        color = vertex_color;
-    }
-    if (is_selected) {
-        if (element_type == 0) {color = selection_color*0.9;}
-        else if (element_type == 1) {color = selection_color*0.8;}
-        else {color = selection_color;}
-        if (alpha < 0.5) alpha = 0.5;
+    color=vertex_color;
+    if(is_selected){
+        if(element_type==0){color=selection_color*.9;}
+        else if(element_type==1){color=selection_color*.8;}
+        else{color=selection_color;}
+        if(alpha<.5)alpha=.5;
     }
 
-    vec3 light_pos = vec3(0, 0, 0);
-    if (is_lighted){
-        vec3 ec_normal = normalize(cross(dFdx(ec_pos), dFdy(ec_pos)));
-        vec3 L = normalize(-ec_pos); 
-        gl_FragColor = vec4(color * dot(ec_normal, L), alpha);
+    vec3 light_pos=vec3(0,0,0);
+    if(is_lighted){
+        vec3 ec_normal=normalize(cross(dFdx(ec_pos),dFdy(ec_pos)));
+        vec3 L=normalize(-ec_pos);
+        gl_FragColor=vec4(color*dot(ec_normal,L),alpha);
     }else{
-        gl_FragColor = vec4(color, alpha);
+        gl_FragColor=vec4(color,alpha);
     }
 }

--- a/src/compas_viewer/configurations/__init__.py
+++ b/src/compas_viewer/configurations/__init__.py
@@ -4,7 +4,7 @@ from .renderer_config import RendererConfig  # noqa: F401
 from .renderer_config import CameraConfig  # noqa: F401
 from .renderer_config import SelectorConfig  # noqa: F401
 from .controller_config import ActionConfig, MouseConfig  # noqa: F401
-from .scene_config import SceneConfig  # noqa: F401
+from .viewer_config import ViewerConfig  # noqa: F401
 from .layout_config import LayoutConfig  # noqa: F401
 from .layout_config import StatusbarConfig  # noqa: F401
 from .layout_config import WindowConfig  # noqa: F401

--- a/src/compas_viewer/configurations/default_config/renderer.json
+++ b/src/compas_viewer/configurations/default_config/renderer.json
@@ -5,7 +5,7 @@
         "gridsize": [10, 10, 10, 10],
         "show_gridz": true,
         "viewmode": "perspective",
-        "rendermode": "shaded",
+        "rendermode": "lightened",
         "backgroundcolor": {
             "dtype": "compas.colors/Color",
             "data": { "red": 1.0, "green": 1.0, "blue": 1.0, "alpha": 1.0 }

--- a/src/compas_viewer/configurations/default_config/scene.json
+++ b/src/compas_viewer/configurations/default_config/scene.json
@@ -13,14 +13,14 @@
             "dtype": "compas.colors/Color",
             "data": { "red": 0.8, "green": 0.8, "blue": 0.8, "alpha": 1.0 }
         },
-        "show_points": false,
+        "show_points": true,
         "show_lines": true,
         "show_faces": true,
         "lineswidth": 1.0,
         "pointssize": 10.0,
         "opacity": 1.0,
         "hide_coplanaredges": false,
-        "use_vertexcolors": true,
+        "use_vertexcolors": false,
         "framesize": [0.1, 10, 0.1, 10],
         "show_framez": true,
         "vectorsize": 0.3

--- a/src/compas_viewer/configurations/default_config/viewer.json
+++ b/src/compas_viewer/configurations/default_config/viewer.json
@@ -1,15 +1,15 @@
 {
-    "dtype": "compas_viewer.configurations/SceneConfig",
+    "dtype": "compas_viewer.configurations/ViewerConfig",
     "data": {
-        "pointscolor": {
+        "pointcolor": {
             "dtype": "compas.colors/Color",
             "data": { "red": 0.2, "green": 0.2, "blue": 0.2, "alpha": 1.0 }
         },
-        "linescolor": {
+        "linecolor": {
             "dtype": "compas.colors/Color",
             "data": { "red": 0.4, "green": 0.4, "blue": 0.4, "alpha": 1.0 }
         },
-        "facescolor": {
+        "surfacecolor": {
             "dtype": "compas.colors/Color",
             "data": { "red": 0.8, "green": 0.8, "blue": 0.8, "alpha": 1.0 }
         },

--- a/src/compas_viewer/configurations/viewer_config.py
+++ b/src/compas_viewer/configurations/viewer_config.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 from compas.colors import Color
 
 from compas_viewer import HERE
@@ -8,19 +7,19 @@ from compas_viewer import HERE
 from .config import Config
 
 
-class SceneConfig(Config):
+class ViewerConfig(Config):
     """
-    The class representation for the `scene.json` of the class ViewerSceneObject.
-    The scene.json contains all the settings about the general (default) appearance of the scene objects.
+    The class representation for the `viewer.json` of the viewer.
+    The viewer.json contains all the settings about the general (default) appearance of the scene objects.
 
     Parameters
     ----------
-    pointscolor : :class:`compas.colors.Color`
+    pointcolor : :class:`compas.colors.Color`
         The default color of the points.
-    linescolor : :class:`compas.colors.Color`
+    linecolor : :class:`compas.colors.Color`
         The default color of the lines.
-    facescolor : :class:`compas.colors.Color`
-        The default color of the faces.
+    surfacecolor : :class:`compas.colors.Color`
+        The default color of the surfaces.
     show_points : bool
         The default setting for showing the points.
     show_lines : bool
@@ -52,9 +51,9 @@ class SceneConfig(Config):
 
     def __init__(
         self,
-        pointscolor: Color,
-        linescolor: Color,
-        facescolor: Color,
+        pointcolor: Color,
+        linecolor: Color,
+        surfacecolor: Color,
         show_points: bool,
         show_lines: bool,
         show_faces: bool,
@@ -69,9 +68,9 @@ class SceneConfig(Config):
     ):
         super().__init__()
 
-        self.pointscolor = pointscolor
-        self.linescolor = linescolor
-        self.facescolor = facescolor
+        self.pointcolor = pointcolor
+        self.linecolor = linecolor
+        self.surfacecolor = surfacecolor
         self.show_points = show_points
         self.show_lines = show_lines
         self.show_faces = show_faces
@@ -87,18 +86,18 @@ class SceneConfig(Config):
             raise ValueError("The vectorsize must be between 0 and 1.")
 
     @classmethod
-    def from_default(cls) -> "SceneConfig":
+    def from_default(cls) -> "ViewerConfig":
         """
         Load the default configuration.
         """
-        scene_config = SceneConfig.from_json(Path(HERE, "configurations", "default_config", "scene.json"))
-        if not isinstance(scene_config, SceneConfig):
-            raise TypeError(f"The {scene_config} is not a valid scene configuration file.")
-        return scene_config
+        viewer_config = ViewerConfig.from_json(Path(HERE, "configurations", "default_config", "scene.json"))
+        if not isinstance(viewer_config, ViewerConfig):
+            raise TypeError(f"The {viewer_config} is not a valid scene configuration file.")
+        return viewer_config
 
     @classmethod
-    def from_json(cls, filepath) -> "SceneConfig":
-        scene_config = super().from_json(filepath)
-        if not isinstance(scene_config, SceneConfig):
+    def from_json(cls, filepath) -> "ViewerConfig":
+        viewer_config = super().from_json(filepath)
+        if not isinstance(viewer_config, ViewerConfig):
             raise TypeError(f"The {filepath} is not a valid scene configuration file.")
-        return scene_config
+        return viewer_config

--- a/src/compas_viewer/configurations/viewer_config.py
+++ b/src/compas_viewer/configurations/viewer_config.py
@@ -90,7 +90,7 @@ class ViewerConfig(Config):
         """
         Load the default configuration.
         """
-        viewer_config = ViewerConfig.from_json(Path(HERE, "configurations", "default_config", "scene.json"))
+        viewer_config = ViewerConfig.from_json(Path(HERE, "configurations", "default_config", "viewer.json"))
         if not isinstance(viewer_config, ViewerConfig):
             raise TypeError(f"The {viewer_config} is not a valid scene configuration file.")
         return viewer_config

--- a/src/compas_viewer/scene/__init__.py
+++ b/src/compas_viewer/scene/__init__.py
@@ -27,7 +27,6 @@ from compas.geometry import (
     Geometry,
 )
 
-from .scene import ViewerScene  # noqa: F401
 from .sceneobject import ViewerSceneObject
 from .meshobject import MeshObject
 from .graphobject import GraphObject
@@ -52,8 +51,9 @@ from .collectionobject import CollectionObject
 
 
 @plugin(category="drawing-utils", requires=["compas_viewer"])
-def clear(guids=None):
-    pass
+def clear(guids: list[str]):
+    for obj in guids:
+        del obj
 
 
 @plugin(category="drawing-utils", requires=["compas_viewer"])

--- a/src/compas_viewer/scene/boxobject.py
+++ b/src/compas_viewer/scene/boxobject.py
@@ -1,10 +1,14 @@
-from compas.datastructures import Mesh
+from typing import Optional, Tuple
+
 from compas.geometry import Box
+from compas.geometry import Line
+from compas.geometry import Point
+from compas.scene import GeometryObject
 
-from .meshobject import MeshObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class BoxObject(MeshObject):
+class BoxObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Box geometry.
 
     See Also
@@ -13,4 +17,41 @@ class BoxObject(MeshObject):
     """
 
     def __init__(self, box: Box, **kwargs):
-        super().__init__(mesh=Mesh.from_shape(box), **kwargs)
+        super().__init__(geometry=box, **kwargs)
+        self.geometry: Box
+
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return self.geometry.to_vertices_and_faces()[0]
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        return [
+            Line(self.geometry.corner(i), self.geometry.corner(j))
+            for i, j in [
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 0),
+                (4, 5),
+                (5, 6),
+                (6, 7),
+                (7, 4),
+                (0, 4),
+                (1, 5),
+                (2, 6),
+                (3, 7),
+            ]
+        ]
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        surface_points = []
+        vertices, faces = self.geometry.to_vertices_and_faces(True)
+        for face in faces:
+            face_points = [vertices[i] for i in face]
+            surface_points.append(face_points)
+        return surface_points

--- a/src/compas_viewer/scene/boxobject.py
+++ b/src/compas_viewer/scene/boxobject.py
@@ -50,4 +50,4 @@ class BoxObject(ViewerGeometryObject, GeometryObject):
     @property
     def viewmesh(self):
         """The mesh volume to be shown in the viewer."""
-        return Mesh.from_shape(self.geometry)
+        return Mesh.from_shape(self.geometry, triangulated=True)

--- a/src/compas_viewer/scene/boxobject.py
+++ b/src/compas_viewer/scene/boxobject.py
@@ -1,5 +1,6 @@
-from typing import Optional, Tuple
+from typing import Optional
 
+from compas.datastructures import Mesh
 from compas.geometry import Box
 from compas.geometry import Line
 from compas.geometry import Point
@@ -47,11 +48,6 @@ class BoxObject(ViewerGeometryObject, GeometryObject):
         ]
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        surface_points = []
-        vertices, faces = self.geometry.to_vertices_and_faces(True)
-        for face in faces:
-            face_points = [vertices[i] for i in face]
-            surface_points.append(face_points)
-        return surface_points
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return Mesh.from_shape(self.geometry)

--- a/src/compas_viewer/scene/brepobject.py
+++ b/src/compas_viewer/scene/brepobject.py
@@ -4,6 +4,7 @@ from compas.datastructures import Mesh
 from compas.geometry import Line
 from compas.geometry import Point
 from compas.scene import GeometryObject
+from compas.tolerance import TOL
 from compas.utilities import pairwise
 
 from .geometryobject import GeometryObject as ViewerGeometryObject
@@ -29,7 +30,7 @@ try:
         def __init__(self, brep: OCCBrep, **kwargs):
             super().__init__(geometry=brep, **kwargs)
             self.geometry: OCCBrep
-            self._viewmesh, self._boundaries = self.geometry.to_tesselation(self.LINEARDEFLECTION)
+            self._viewmesh, self._boundaries = self.geometry.to_tesselation(TOL.lineardeflection)
 
         @property
         def points(self) -> Optional[list[Point]]:

--- a/src/compas_viewer/scene/brepobject.py
+++ b/src/compas_viewer/scene/brepobject.py
@@ -1,6 +1,6 @@
 from typing import Optional
-from typing import Tuple
 
+from compas.datastructures import Mesh
 from compas.geometry import Line
 from compas.geometry import Point
 from compas.scene import GeometryObject
@@ -29,7 +29,7 @@ try:
         def __init__(self, brep: OCCBrep, **kwargs):
             super().__init__(geometry=brep, **kwargs)
             self.geometry: OCCBrep
-            self.mesh, self.boundaries = self.geometry.to_tesselation(self.LINEARDEFLECTION)
+            self._viewmesh, self._boundaries = self.geometry.to_tesselation(self.LINEARDEFLECTION)
 
         @property
         def points(self) -> Optional[list[Point]]:
@@ -40,21 +40,16 @@ try:
         def lines(self) -> Optional[list[Line]]:
             """The lines to be shown in the viewer."""
             lines = []
-            for polyline in self.boundaries:
+            for polyline in self._boundaries:
                 for pair in pairwise(polyline.points):
                     lines.append(Line(*pair))
 
             return lines
 
         @property
-        def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-            """The surface to be shown in the viewer. Currently only triangles are supported."""
-            surface_points = []
-            vertices, faces = self.mesh.to_vertices_and_faces()
-            for face in faces:
-                face_points = [vertices[i] for i in face]
-                surface_points.append(face_points)
-            return surface_points
+        def viewmesh(self) -> Mesh:
+            """The mesh volume to be shown in the viewer."""
+            return self._viewmesh
 
 except ImportError:
     pass

--- a/src/compas_viewer/scene/capsuleobject.py
+++ b/src/compas_viewer/scene/capsuleobject.py
@@ -1,7 +1,7 @@
 from math import pi
 from typing import Optional
-from typing import Tuple
 
+from compas.datastructures import Mesh
 from compas.geometry import Capsule
 from compas.geometry import Line
 from compas.geometry import Point
@@ -27,18 +27,13 @@ class CapsuleObject(ViewerGeometryObject, GeometryObject):
     @property
     def points(self) -> Optional[list[Point]]:
         """The points to be shown in the viewer."""
-        pass
+        return None
 
     @property
     def lines(self) -> Optional[list[Line]]:
-        pass
+        return None
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        surface_points = []
-        vertices, faces = self.geometry.to_vertices_and_faces(self.u, self.v, True)
-        for face in faces:
-            face_points = [vertices[i] for i in face]
-            surface_points.append(face_points)
-        return surface_points
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)

--- a/src/compas_viewer/scene/capsuleobject.py
+++ b/src/compas_viewer/scene/capsuleobject.py
@@ -36,4 +36,4 @@ class CapsuleObject(ViewerGeometryObject, GeometryObject):
     @property
     def viewmesh(self):
         """The mesh volume to be shown in the viewer."""
-        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)
+        return Mesh.from_shape(self.geometry, u=self.u, v=self.v, triangulated=True)

--- a/src/compas_viewer/scene/capsuleobject.py
+++ b/src/compas_viewer/scene/capsuleobject.py
@@ -1,4 +1,3 @@
-from math import pi
 from typing import Optional
 
 from compas.datastructures import Mesh
@@ -21,8 +20,6 @@ class CapsuleObject(ViewerGeometryObject, GeometryObject):
     def __init__(self, capsule: Capsule, **kwargs):
         super().__init__(geometry=capsule, **kwargs)
         self.geometry: Capsule
-        self.u = int(2 * pi * capsule.radius / self.LINEARDEFLECTION)
-        self.v = self.u
 
     @property
     def points(self) -> Optional[list[Point]]:

--- a/src/compas_viewer/scene/capsuleobject.py
+++ b/src/compas_viewer/scene/capsuleobject.py
@@ -1,12 +1,16 @@
 from math import pi
+from typing import Optional
+from typing import Tuple
 
-from compas.datastructures import Mesh
 from compas.geometry import Capsule
+from compas.geometry import Line
+from compas.geometry import Point
+from compas.scene import GeometryObject
 
-from .meshobject import MeshObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class CapsuleObject(MeshObject):
+class CapsuleObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Capsule geometry.
 
     See Also
@@ -15,6 +19,26 @@ class CapsuleObject(MeshObject):
     """
 
     def __init__(self, capsule: Capsule, **kwargs):
-        self.u = kwargs.get("u", int(2 * pi * capsule.radius / self.LINEARDEFLECTION))
+        super().__init__(geometry=capsule, **kwargs)
+        self.geometry: Capsule
+        self.u = int(2 * pi * capsule.radius / self.LINEARDEFLECTION)
+        self.v = self.u
 
-        super().__init__(mesh=Mesh.from_shape(capsule, u=self.u), **kwargs)
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        pass
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        pass
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        surface_points = []
+        vertices, faces = self.geometry.to_vertices_and_faces(self.u, self.v, True)
+        for face in faces:
+            face_points = [vertices[i] for i in face]
+            surface_points.append(face_points)
+        return surface_points

--- a/src/compas_viewer/scene/circleobject.py
+++ b/src/compas_viewer/scene/circleobject.py
@@ -1,6 +1,5 @@
 import math
 from typing import Optional
-from typing import Tuple
 
 from compas.geometry import Circle
 from compas.geometry import Line

--- a/src/compas_viewer/scene/circleobject.py
+++ b/src/compas_viewer/scene/circleobject.py
@@ -53,6 +53,6 @@ class CircleObject(ViewerGeometryObject, GeometryObject):
         ]
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        pass
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return None

--- a/src/compas_viewer/scene/circleobject.py
+++ b/src/compas_viewer/scene/circleobject.py
@@ -21,7 +21,6 @@ class CircleObject(ViewerGeometryObject, GeometryObject):
     def __init__(self, circle: Circle, **kwargs):
         super().__init__(geometry=circle, **kwargs)
         self.geometry: Circle
-        self.u = int(circle.circumference / self.LINEARDEFLECTION)
         self.show_lines = True
 
     def _calculate_circle_points(self, circle):

--- a/src/compas_viewer/scene/collectionobject.py
+++ b/src/compas_viewer/scene/collectionobject.py
@@ -6,7 +6,7 @@ from compas.geometry import Geometry
 from compas.scene import GeometryObject
 from numpy import array
 
-from .sceneobject import DataType
+from .sceneobject import ShaderDataType
 from .sceneobject import ViewerSceneObject
 
 
@@ -30,7 +30,7 @@ class CollectionObject(ViewerSceneObject, GeometryObject):
         super().__init__(geometry=self.collection, **kwargs)
         self.objects = [ViewerSceneObject(item=item, **kwargs) for item in self.collection.items]
 
-    def _read_points_data(self) -> DataType:
+    def _read_points_data(self) -> ShaderDataType:
         positions = []
         colors = []
         elements = []
@@ -43,7 +43,7 @@ class CollectionObject(ViewerSceneObject, GeometryObject):
             count += len(p)
         return positions, colors, elements
 
-    def _read_lines_data(self) -> DataType:
+    def _read_lines_data(self) -> ShaderDataType:
         positions = []
         colors = []
         elements = []
@@ -56,7 +56,7 @@ class CollectionObject(ViewerSceneObject, GeometryObject):
             count += len(p)
         return positions, colors, elements
 
-    def _read_frontfaces_data(self) -> DataType:
+    def _read_frontfaces_data(self) -> ShaderDataType:
         positions = []
         colors = []
         elements = []
@@ -69,7 +69,7 @@ class CollectionObject(ViewerSceneObject, GeometryObject):
             count += len(p)
         return positions, colors, elements
 
-    def _read_backfaces_data(self) -> DataType:
+    def _read_backfaces_data(self) -> ShaderDataType:
         positions = []
         colors = []
         elements = []

--- a/src/compas_viewer/scene/coneobject.py
+++ b/src/compas_viewer/scene/coneobject.py
@@ -36,4 +36,4 @@ class ConeObject(ViewerGeometryObject, GeometryObject):
     @property
     def viewmesh(self) -> Mesh:
         """The mesh volume to be shown in the viewer."""
-        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)
+        return Mesh.from_shape(self.geometry, u=self.u, triangulated=True)

--- a/src/compas_viewer/scene/coneobject.py
+++ b/src/compas_viewer/scene/coneobject.py
@@ -1,4 +1,3 @@
-from math import pi
 from typing import Optional
 
 from compas.datastructures import Mesh
@@ -21,8 +20,6 @@ class ConeObject(ViewerGeometryObject, GeometryObject):
     def __init__(self, cone: Cone, **kwargs):
         super().__init__(geometry=cone, **kwargs)
         self.geometry: Cone
-        self.u = int(2 * pi * cone.radius / self.LINEARDEFLECTION)
-        self.v = self.u
 
     @property
     def points(self) -> Optional[list[Point]]:

--- a/src/compas_viewer/scene/coneobject.py
+++ b/src/compas_viewer/scene/coneobject.py
@@ -1,7 +1,7 @@
 from math import pi
 from typing import Optional
-from typing import Tuple
 
+from compas.datastructures import Mesh
 from compas.geometry import Cone
 from compas.geometry import Line
 from compas.geometry import Point
@@ -27,18 +27,13 @@ class ConeObject(ViewerGeometryObject, GeometryObject):
     @property
     def points(self) -> Optional[list[Point]]:
         """The points to be shown in the viewer."""
-        pass
+        return None
 
     @property
     def lines(self) -> Optional[list[Line]]:
-        pass
+        return None
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        surface_points = []
-        vertices, faces = self.geometry.to_vertices_and_faces(self.u, True)
-        for face in faces:
-            face_points = [vertices[i] for i in face]
-            surface_points.append(face_points)
-        return surface_points
+    def viewmesh(self) -> Mesh:
+        """The mesh volume to be shown in the viewer."""
+        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)

--- a/src/compas_viewer/scene/coneobject.py
+++ b/src/compas_viewer/scene/coneobject.py
@@ -1,12 +1,16 @@
 from math import pi
+from typing import Optional
+from typing import Tuple
 
-from compas.datastructures import Mesh
 from compas.geometry import Cone
+from compas.geometry import Line
+from compas.geometry import Point
+from compas.scene import GeometryObject
 
-from .meshobject import MeshObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class ConeObject(MeshObject):
+class ConeObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Cone geometry.
 
     See Also
@@ -15,6 +19,26 @@ class ConeObject(MeshObject):
     """
 
     def __init__(self, cone: Cone, **kwargs):
-        self.u = kwargs.get("u", int(2 * pi * cone.radius / self.LINEARDEFLECTION))
+        super().__init__(geometry=cone, **kwargs)
+        self.geometry: Cone
+        self.u = int(2 * pi * cone.radius / self.LINEARDEFLECTION)
+        self.v = self.u
 
-        super().__init__(mesh=Mesh.from_shape(shape=cone, u=self.u), **kwargs)
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        pass
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        pass
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        surface_points = []
+        vertices, faces = self.geometry.to_vertices_and_faces(self.u, True)
+        for face in faces:
+            face_points = [vertices[i] for i in face]
+            surface_points.append(face_points)
+        return surface_points

--- a/src/compas_viewer/scene/cylinderobject.py
+++ b/src/compas_viewer/scene/cylinderobject.py
@@ -36,4 +36,4 @@ class CylinderObject(ViewerGeometryObject, GeometryObject):
     @property
     def viewmesh(self):
         """The mesh volume to be shown in the viewer."""
-        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)
+        return Mesh.from_shape(self.geometry, u=self.u, triangulated=True)

--- a/src/compas_viewer/scene/cylinderobject.py
+++ b/src/compas_viewer/scene/cylinderobject.py
@@ -1,4 +1,3 @@
-from math import pi
 from typing import Optional
 
 from compas.datastructures import Mesh
@@ -21,8 +20,6 @@ class CylinderObject(ViewerGeometryObject, GeometryObject):
     def __init__(self, cylinder: Cylinder, **kwargs):
         super().__init__(geometry=cylinder, **kwargs)
         self.geometry: Cylinder
-        self.u = int(2 * pi * cylinder.radius / self.LINEARDEFLECTION)
-        self.v = self.u
 
     @property
     def points(self) -> Optional[list[Point]]:

--- a/src/compas_viewer/scene/cylinderobject.py
+++ b/src/compas_viewer/scene/cylinderobject.py
@@ -1,12 +1,16 @@
 from math import pi
+from typing import Optional
+from typing import Tuple
 
-from compas.datastructures import Mesh
 from compas.geometry import Cylinder
+from compas.geometry import Line
+from compas.geometry import Point
+from compas.scene import GeometryObject
 
-from .meshobject import MeshObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class CylinderObject(MeshObject):
+class CylinderObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Cylinder geometry.
 
     See Also
@@ -15,6 +19,25 @@ class CylinderObject(MeshObject):
     """
 
     def __init__(self, cylinder: Cylinder, **kwargs):
-        self.u = kwargs.get("u", int(2 * pi * cylinder.radius / self.LINEARDEFLECTION))
+        super().__init__(geometry=cylinder, **kwargs)
+        self.geometry: Cylinder
+        self.u = int(2 * pi * cylinder.radius / self.LINEARDEFLECTION)
 
-        super().__init__(mesh=Mesh.from_shape(cylinder, u=self.u), **kwargs)
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        pass
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        pass
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        surface_points = []
+        vertices, faces = self.geometry.to_vertices_and_faces(self.u, True)
+        for face in faces:
+            face_points = [vertices[i] for i in face]
+            surface_points.append(face_points)
+        return surface_points

--- a/src/compas_viewer/scene/cylinderobject.py
+++ b/src/compas_viewer/scene/cylinderobject.py
@@ -1,7 +1,7 @@
 from math import pi
 from typing import Optional
-from typing import Tuple
 
+from compas.datastructures import Mesh
 from compas.geometry import Cylinder
 from compas.geometry import Line
 from compas.geometry import Point
@@ -22,22 +22,18 @@ class CylinderObject(ViewerGeometryObject, GeometryObject):
         super().__init__(geometry=cylinder, **kwargs)
         self.geometry: Cylinder
         self.u = int(2 * pi * cylinder.radius / self.LINEARDEFLECTION)
+        self.v = self.u
 
     @property
     def points(self) -> Optional[list[Point]]:
         """The points to be shown in the viewer."""
-        pass
+        return None
 
     @property
     def lines(self) -> Optional[list[Line]]:
-        pass
+        return None
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        surface_points = []
-        vertices, faces = self.geometry.to_vertices_and_faces(self.u, True)
-        for face in faces:
-            face_points = [vertices[i] for i in face]
-            surface_points.append(face_points)
-        return surface_points
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)

--- a/src/compas_viewer/scene/ellipseobject.py
+++ b/src/compas_viewer/scene/ellipseobject.py
@@ -58,9 +58,9 @@ class EllipseObject(ViewerGeometryObject, GeometryObject):
         return [Line(line_points[i - 1], line_points[i]) for i in range(0, self.u)]
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        return []
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return None
 
     def _proximate_circumference(self):
         return 2 * pi * sqrt((self.geometry.major**2 + self.geometry.minor**2) / 2)

--- a/src/compas_viewer/scene/ellipseobject.py
+++ b/src/compas_viewer/scene/ellipseobject.py
@@ -32,7 +32,6 @@ class EllipseObject(ViewerGeometryObject, GeometryObject):
     def __init__(self, ellipse: Ellipse, **kwargs):
         super().__init__(geometry=ellipse, **kwargs)
         self.geometry: Ellipse
-        self.u = int(self._proximate_circumference() / self.LINEARDEFLECTION)
         self.show_lines = True
 
     @property

--- a/src/compas_viewer/scene/ellipseobject.py
+++ b/src/compas_viewer/scene/ellipseobject.py
@@ -2,18 +2,28 @@ from math import cos
 from math import pi
 from math import sin
 from math import sqrt
+from typing import Optional
+from typing import Tuple
 
 from compas.geometry import Ellipse
 from compas.geometry import Frame
+from compas.geometry import Line
+from compas.geometry import Point
 from compas.scene import GeometryObject
-from compas.utilities import pairwise
 
-from .sceneobject import DataType
-from .sceneobject import ViewerSceneObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class EllipseObject(ViewerSceneObject, GeometryObject):
+class EllipseObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Ellipse geometry.
+
+    Parameters
+    ----------
+    ellipse : :class:`compas.geometry.Ellipse`
+        A COMPAS ellipse geometry.
+    **kwargs : dict, optional
+        Additional options for the :class:`compas_viewer.scene.ViewerSceneObject`
+        and :class:`compas.scene.GeometryObject`.
 
     See Also
     --------
@@ -21,55 +31,36 @@ class EllipseObject(ViewerSceneObject, GeometryObject):
     """
 
     def __init__(self, ellipse: Ellipse, **kwargs):
-        self.geometry = ellipse
-        self.u = kwargs.get("u", int(self._proximate_circumference / self.LINEARDEFLECTION))
-        self.u_points = self._calculate_ellipse_points(ellipse)
-        super().__init__(geometry=ellipse, close=True, **kwargs)
+        super().__init__(geometry=ellipse, **kwargs)
+        self.geometry: Ellipse
+        self.u = int(self._proximate_circumference() / self.LINEARDEFLECTION)
+        self.show_lines = True
 
     @property
-    def _proximate_circumference(self):
-        return 2 * pi * sqrt((self.geometry.major**2 + self.geometry.minor**2) / 2)
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return [self.geometry.plane.point]
 
-    def _calculate_ellipse_points(self, ellipse):
-        frame = Frame.from_plane(ellipse.plane)
-        return [
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        frame = Frame.from_plane(self.geometry.plane)
+        line_points = [
             frame.to_world_coordinates(
-                [
-                    cos(i * pi * 2 / self.u) * ellipse.major,
-                    sin(i * pi * 2 / self.u) * ellipse.minor,
+                Point(
+                    cos(i * pi * 2 / self.u) * self.geometry.major,
+                    sin(i * pi * 2 / self.u) * self.geometry.minor,
                     0,
-                ]
+                )
             )
             for i in range(self.u)
         ]
+        return [Line(line_points[i - 1], line_points[i]) for i in range(0, self.u)]
 
-    def _read_points_data(self) -> DataType:
-        positions = []
-        colors = []
-        elements = []
-        i = 0
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        return []
 
-        for i, u_point in enumerate(self.u_points):
-            positions.append(u_point)
-            colors.append(self.pointscolor.get(i, self.pointscolor["_default"]))  # type: ignore
-            elements.append([i])
-            i += 1
-
-        return positions, colors, elements
-
-    def _read_lines_data(self) -> DataType:
-        positions = []
-        colors = []
-        elements = []
-        i = 0
-        count = 0
-        lines = pairwise(self.u_points + [self.u_points[0]])
-        count = 0
-        for i, (pt1, pt2) in enumerate(lines):
-            positions.append(pt1)
-            positions.append(pt2)
-            colors.append(self.pointscolor.get(i, self.pointscolor["_default"]))  # type: ignore
-            colors.append(self.pointscolor.get(i, self.pointscolor["_default"]))  # type: ignore
-            elements.append([count, count + 1])
-            count += 2
-        return positions, colors, elements
+    def _proximate_circumference(self):
+        return 2 * pi * sqrt((self.geometry.major**2 + self.geometry.minor**2) / 2)

--- a/src/compas_viewer/scene/ellipseobject.py
+++ b/src/compas_viewer/scene/ellipseobject.py
@@ -3,7 +3,6 @@ from math import pi
 from math import sin
 from math import sqrt
 from typing import Optional
-from typing import Tuple
 
 from compas.geometry import Ellipse
 from compas.geometry import Frame

--- a/src/compas_viewer/scene/frameobject.py
+++ b/src/compas_viewer/scene/frameobject.py
@@ -129,12 +129,12 @@ class FrameObject(ViewerSceneObject):
 
     def _read_points_data(self) -> Optional[ShaderDataType]:
         """Read points data from the object."""
-        pass
+        return None
 
     def _read_frontfaces_data(self) -> Optional[ShaderDataType]:
         """Read frontfaces data from the object."""
-        pass
+        return None
 
     def _read_backfaces_data(self) -> Optional[ShaderDataType]:
         """Read backfaces data from the object."""
-        pass
+        return None

--- a/src/compas_viewer/scene/frameobject.py
+++ b/src/compas_viewer/scene/frameobject.py
@@ -21,6 +21,8 @@ class FrameObject(ViewerSceneObject):
     framesize : tuple[float, int, float, int]
         The size of the grid in [dx, nx, dy, ny] format.
         Notice that the `nx` and `ny` must be even numbers.
+    linecolor : :class:`compas.colors.Color`
+        The color of the grid lines.
     show_framez : bool
         If True, the Z axis of the grid will be shown.
 
@@ -39,10 +41,6 @@ class FrameObject(ViewerSceneObject):
     show_framez : bool
         If the Z axis of the grid is shown.
 
-    Notes
-    -----
-    The frame object is always unselectable.
-
     See Also
     --------
     :class:`compas.geometry.Frame`
@@ -58,7 +56,7 @@ class FrameObject(ViewerSceneObject):
     ):
         super().__init__(item=frame, **kwargs)
         self.frame = frame
-        self.linecolor = linecolor or self.viewer.config.linescolor
+        self.linecolor = linecolor or self.viewer.config.linecolor
         self.dx = framesize[0] if framesize else self.viewer.config.framesize[0]
         self.nx = framesize[1] if framesize else self.viewer.config.framesize[1]
         self.dy = framesize[2] if framesize else self.viewer.config.framesize[2]

--- a/src/compas_viewer/scene/geometryobject.py
+++ b/src/compas_viewer/scene/geometryobject.py
@@ -1,0 +1,124 @@
+from typing import Optional
+from typing import Tuple
+
+from compas.colors import Color
+from compas.geometry import Geometry
+from compas.geometry import Line
+from compas.geometry import Point
+from compas.scene import GeometryObject as BaseGeometryObject
+
+from .sceneobject import ShaderDataType
+from .sceneobject import ViewerSceneObject
+
+
+class GeometryObject(ViewerSceneObject, BaseGeometryObject):
+    """Viewer scene object for displaying COMPAS Geometry.
+
+    Parameters
+    ----------
+    geometry : :class:`compas.geometry.Geometry`
+        A COMPAS geometry.
+    pointcolor : :class:`compas.colors.Color`, optional
+        The color of the points. Global settings in the viewer will be used if not specified.
+    linecolor : :class:`compas.colors.Color`, optional
+        The color of the lines. Global settings in the viewer will be used if not specified.
+    surfacecolor : :class:`compas.colors.Color`, optional
+        The color of the surfaces. Global settings in the viewer will be used if not specified.
+    **kwargs : dict, optional
+        Additional options for the :class:`compas_viewer.scene.ViewerSceneObject`
+        and :class:`compas.scene.GeometryObject`.
+
+    Attributes
+    ----------
+    geometry : :class:`compas.geometry.Geometry`
+        The COMPAS geometry.
+    pointcolor : :class:`compas.colors.Color`
+        The color of the points.
+    linecolor : :class:`compas.colors.Color`
+        The color of the lines.
+    surfacecolor : :class:`compas.colors.Color`
+        The color of the surfaces.
+    mesh : :class:`compas.datastructures.Mesh`
+        The triangulated mesh representation of the geometry.
+    LINEARDEFLECTION : float
+        The default linear deflection for the geometry.
+
+    See Also
+    --------
+    :class:`compas.geometry.Geometry`
+    """
+
+    LINEARDEFLECTION = 0.2
+
+    def __init__(
+        self,
+        geometry: Geometry,
+        pointcolor: Optional[Color] = None,
+        linecolor: Optional[Color] = None,
+        surfacecolor: Optional[Color] = None,
+        **kwargs
+    ):
+
+        super().__init__(geometry=geometry, **kwargs)
+        self.geometry: Geometry
+
+        self.pointcolor = pointcolor or self.viewer.config.pointscolor
+        self.linecolor = linecolor or self.viewer.config.linescolor
+        self.surfacecolor = surfacecolor or self.viewer.config.facescolor
+
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        raise NotImplementedError
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        raise NotImplementedError
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        raise NotImplementedError
+
+    def _read_points_data(self) -> ShaderDataType:
+        if self.points is None:
+            return [], [], []
+        positions = self.points
+        colors = [self.pointcolor] * len(positions)
+        elements = [[i] for i in range(len(positions))]
+        return positions, colors, elements
+
+    def _read_lines_data(self) -> ShaderDataType:
+        if self.lines is None:
+            return [], [], []
+        positions = []
+        for line in self.lines:
+            positions.append(line.start)
+            positions.append(line.end)
+        colors = [self.linecolor] * 2 * len(positions)
+        elements = [[2 * i, 2 * i + 1] for i in range(len(positions))]
+
+        return positions, colors, elements
+
+    def _read_frontfaces_data(self) -> ShaderDataType:
+        if self.surfaces is None:
+            return [], [], []
+        positions = []
+        for surface in self.surfaces:
+            positions.extend(surface)
+        colors = [self.surfacecolor] * 3 * len(positions)
+        elements = [[3 * i, 3 * i + 1, 3 * i + 2] for i in range(len(positions))]
+
+        return positions, colors, elements
+
+    def _read_backfaces_data(self) -> ShaderDataType:
+        if self.surfaces is None:
+            return [], [], []
+        positions = []
+        for surface in self.surfaces:
+            positions.extend(surface[::-1])
+        colors = [self.surfacecolor] * 3 * len(positions)
+        elements = [[3 * i, 3 * i + 1, 3 * i + 2] for i in range(len(positions))]
+
+        return positions, colors, elements

--- a/src/compas_viewer/scene/geometryobject.py
+++ b/src/compas_viewer/scene/geometryobject.py
@@ -18,6 +18,10 @@ class GeometryObject(ViewerSceneObject, BaseGeometryObject):
     ----------
     geometry : :class:`compas.geometry.Geometry`
         A COMPAS geometry.
+    v : int, optional
+        The number of vertices in the u-direction of non-OCC geometries.
+    u : int, optional
+        The number of vertices in the v-direction of non-OCC geometries.
     pointcolor : :class:`compas.colors.Color`, optional
         The color of the points. Default is the value of `pointcolor` in `viewer.config`.
     linecolor : :class:`compas.colors.Color`, optional
@@ -48,11 +52,11 @@ class GeometryObject(ViewerSceneObject, BaseGeometryObject):
     :class:`compas.geometry.Geometry`
     """
 
-    LINEARDEFLECTION = 0.2
-
     def __init__(
         self,
         geometry: Geometry,
+        u: int,
+        v: int,
         pointcolor: Optional[Color] = None,
         linecolor: Optional[Color] = None,
         surfacecolor: Optional[Color] = None,
@@ -62,6 +66,8 @@ class GeometryObject(ViewerSceneObject, BaseGeometryObject):
         super().__init__(geometry=geometry, **kwargs)
         self.geometry: Geometry
 
+        self.u = u
+        self.v = v
         self.pointcolor = pointcolor or self.viewer.config.pointcolor
         self.linecolor = linecolor or self.viewer.config.linecolor
         self.surfacecolor = surfacecolor or self.viewer.config.surfacecolor

--- a/src/compas_viewer/scene/graphobject.py
+++ b/src/compas_viewer/scene/graphobject.py
@@ -41,6 +41,6 @@ class GraphObject(ViewerGeometryObject, BaseGraphObject):
         return [Line(self.graph.node_coordinates(u), self.graph.node_coordinates(v)) for u, v in self.graph.edges()]
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        pass
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return None

--- a/src/compas_viewer/scene/graphobject.py
+++ b/src/compas_viewer/scene/graphobject.py
@@ -1,11 +1,15 @@
+from typing import Optional
+from typing import Tuple
+
 from compas.datastructures import Graph
+from compas.geometry import Line
+from compas.geometry import Point
 from compas.scene import GraphObject as BaseGraphObject
 
-from .sceneobject import DataType
-from .sceneobject import ViewerSceneObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class GraphObject(ViewerSceneObject, BaseGraphObject):
+class GraphObject(ViewerGeometryObject, BaseGraphObject):
     """Viewer scene object for displaying COMPAS Graph data.
 
 
@@ -26,31 +30,17 @@ class GraphObject(ViewerSceneObject, BaseGraphObject):
         super().__init__(graph=graph, **kwargs)
         self.graph: Graph
 
-    def _read_points_data(self) -> DataType:
-        positions = []
-        colors = []
-        elements = []
-        i = 0
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return [Point(*self.graph.node_coordinates(node)) for node in self.graph.nodes()]
 
-        for node in self.graph.nodes():
-            positions.append(self.graph.node_coordinates(node))
-            colors.append(self.pointscolor.get(node, self.pointscolor["_default"]))  # type: ignore
-            elements.append([i])
-            i += 1
-        return positions, colors, elements
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        return [Line(self.graph.node_coordinates(u), self.graph.node_coordinates(v)) for u, v in self.graph.edges()]
 
-    def _read_lines_data(self) -> DataType:
-        positions = []
-        colors = []
-        elements = []
-        i = 0
-
-        for u, v in self.graph.edges():
-            color = self.linescolor.get((u, v), self.linescolor["_default"])  # type: ignore
-            positions.append(self.graph.node_coordinates(u))
-            positions.append(self.graph.node_coordinates(v))
-            colors.append(color)
-            colors.append(color)
-            elements.append([i + 0, i + 1])
-            i += 2
-        return positions, colors, elements
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        pass

--- a/src/compas_viewer/scene/graphobject.py
+++ b/src/compas_viewer/scene/graphobject.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from typing import Tuple
 
 from compas.datastructures import Graph
 from compas.geometry import Line

--- a/src/compas_viewer/scene/gridobject.py
+++ b/src/compas_viewer/scene/gridobject.py
@@ -1,0 +1,59 @@
+from typing import Optional
+
+from compas.colors import Color
+from compas.geometry import Frame
+
+from .frameobject import FrameObject
+
+
+class GridObject(FrameObject):
+    """
+    The scene object of the world XY grid. It is a subclass of the FrameObject.
+
+    Parameters
+    ----------
+    frame : :class:`compas.geometry.Frame`
+        The transformation frame. The default is the world XY frame.
+    framesize : tuple[float, int, float, int]
+        The size of the grid in [dx, nx, dy, ny] format.
+        Notice that the `nx` and `ny` must be even numbers.
+    linecolor : :class:`compas.colors.Color`
+        The color of the grid lines.
+    show_framez : bool
+        If True, the Z axis of the grid will be shown.
+
+    Attributes
+    ----------
+    frame : :class:`compas.geometry.Frame`
+        The transformation frame.
+    dx : float
+        The size of the grid in the X direction.
+    nx : int
+        The number of grid cells in the X direction.
+    dy : float
+        The size of the grid in the Y direction.
+    ny : int
+        The number of grid cells in the Y direction.
+    show_framez : bool
+        If the Z axis of the grid is shown.
+
+    Notes
+    -----
+    The world grid object is always unselectable.
+
+    See Also
+    --------
+    :class:`compas_viewer.scene.FrameObject`
+    :class:`compas.geometry.Frame`
+    """
+
+    def __init__(
+        self,
+        frame: Frame = Frame.worldXY(),
+        framesize: Optional[tuple[float, int, float, int]] = None,
+        linecolor: Optional[Color] = None,
+        show_framez: Optional[bool] = None,
+        **kwargs
+    ):
+        super().__init__(frame=frame, framesize=framesize, linecolor=linecolor, show_framez=show_framez, **kwargs)
+        self.is_locked = True

--- a/src/compas_viewer/scene/lineobject.py
+++ b/src/compas_viewer/scene/lineobject.py
@@ -32,6 +32,6 @@ class LineObject(ViewerGeometryObject, GeometryObject):
         return [self.geometry]
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        pass
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return None

--- a/src/compas_viewer/scene/lineobject.py
+++ b/src/compas_viewer/scene/lineobject.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from typing import Tuple
 
 from compas.geometry import Line
 from compas.geometry import Point

--- a/src/compas_viewer/scene/lineobject.py
+++ b/src/compas_viewer/scene/lineobject.py
@@ -1,11 +1,14 @@
+from typing import Optional
+from typing import Tuple
+
 from compas.geometry import Line
+from compas.geometry import Point
 from compas.scene import GeometryObject
 
-from .sceneobject import DataType
-from .sceneobject import ViewerSceneObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class LineObject(ViewerSceneObject, GeometryObject):
+class LineObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Line geometry.
 
     See Also
@@ -14,24 +17,21 @@ class LineObject(ViewerSceneObject, GeometryObject):
     """
 
     def __init__(self, line: Line, **kwargs):
-        if kwargs["show_lines"] is None:
-            kwargs["show_lines"] = True
         super().__init__(geometry=line, **kwargs)
+        self.geometry: Line
+        self.show_lines = True
 
-    def _read_points_data(self) -> DataType:
-        positions = [self.geometry.start, self.geometry.end]
-        colors = [
-            self.pointscolor.get(0, self.pointscolor["_default"]),  # type: ignore
-            self.pointscolor.get(1, self.pointscolor["_default"]),  # type: ignore
-        ]
-        elements = [[0], [1]]
-        return positions, colors, elements
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return [self.geometry.start, self.geometry.end]
 
-    def _read_lines_data(self) -> DataType:
-        positions = [self.geometry.start, self.geometry.end]
-        colors = [
-            self.linescolor.get(0, self.linescolor["_default"]),  # type: ignore
-            self.linescolor.get(1, self.linescolor["_default"]),  # type: ignore
-        ]
-        elements = [[0, 1]]
-        return positions, colors, elements
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        return [self.geometry]
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        pass

--- a/src/compas_viewer/scene/meshobject.py
+++ b/src/compas_viewer/scene/meshobject.py
@@ -24,15 +24,15 @@ class MeshObject(ViewerSceneObject, BaseMeshObject):
     mesh : :class:`compas.datastructures.Mesh`
         A COMPAS mesh.
     vertexcolor : Union[Dict[Any, :class:`compas.colors.Color`], :class:`compas.colors.Color`]], optional
-        The vertex color. Global settings in the viewer will be used if not specified.
+        The vertex color. Defaults to the value of `pointcolor` in `viewer.config`.
     edgecolor : Union[Dict[Any, :class:`compas.colors.Color`], :class:`compas.colors.Color`]], optional
-        The edge color. Global settings in the viewer will be used if not specified.
+        The edge color. Defaults to the value of `linecolor` in `viewer.config`.
     facecolor : Union[Dict[Any, :class:`compas.colors.Color`], :class:`compas.colors.Color`]], optional
-        The face color. Global settings in the viewer will be used if not specified.
+        The face color. Defaults to the value of `surfacecolor` in `viewer.config`.
     hide_coplanaredges : bool, optional
-        True to hide the coplanar edges. Global settings in the viewer will be used if not specified.
+        True to hide the coplanar edges. Defaults to the value of `hide_coplanaredges` in `viewer.config`.
     use_vertexcolors : bool, optional
-        True to use vertex color. Global settings in the viewer will be used if not specified.
+        True to use vertex color. Defaults to the value of `use_vertexcolors` in `viewer.config`.
     **kwargs : dict, optional
         Additional options for the :class:`compas_viewer.scene.ViewerSceneObject` and :class:`compas.scene.MeshObject`.
 
@@ -72,21 +72,21 @@ class MeshObject(ViewerSceneObject, BaseMeshObject):
         )
 
         if not vertexcolor:
-            self.vertexcolor = self.viewer.config.pointscolor
+            self.vertexcolor = self.viewer.config.pointcolor
             for vertex in self.mesh.vertices():
                 self.vertexcolor[vertex] = self.mesh.vertex_attribute(vertex, "color")  # type: ignore
         else:
             self.vertexcolor = vertexcolor
 
         if not edgecolor:
-            self.edgecolor = self.viewer.config.linescolor
+            self.edgecolor = self.viewer.config.linecolor
             for u, v in self.mesh.edges():
                 self.edgecolor[(u, v)] = self.mesh.edge_attribute((u, v), "color")  # type: ignore
         else:
             self.edgecolor = edgecolor
 
         if not facecolor:
-            self.facecolor = self.viewer.config.facescolor
+            self.facecolor = self.viewer.config.surfacecolor
             for face in self.mesh.faces():
                 self.facecolor[face] = self.mesh.face_attribute(face, "color")  # type: ignore
         else:

--- a/src/compas_viewer/scene/meshobject.py
+++ b/src/compas_viewer/scene/meshobject.py
@@ -270,10 +270,10 @@ class MeshObject(ViewerSceneObject, BaseMeshObject):
         return positions, colors, elements
 
     def draw_vertices(self):
-        pass
+        return None
 
     def draw_edges(self):
-        pass
+        return None
 
     def draw_faces(self):
-        pass
+        return None

--- a/src/compas_viewer/scene/nurbssurfaceobject.py
+++ b/src/compas_viewer/scene/nurbssurfaceobject.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from typing import Tuple
 
 from compas.datastructures import Mesh
 from compas.geometry import Line
@@ -23,8 +22,8 @@ class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
         self.geometry: NurbsSurface
 
         # LINEARDEFLECTION not implemented in NurbsSurface.
-        self.u = int(16 + (0 * self.LINEARDEFLECTION))
-        self.v = int(16 + (0 * self.LINEARDEFLECTION))
+        self.nu = int(16 + (0 * self.LINEARDEFLECTION))
+        self.nv = int(16 + (0 * self.LINEARDEFLECTION))
 
     @property
     def points(self) -> Optional[list[Point]]:
@@ -49,4 +48,9 @@ class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
     @property
     def viewmesh(self) -> Mesh:
         """The mesh volume to be shown in the viewer."""
-        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)
+        vertices = []
+        faces = []
+        for n, triangle in enumerate(self.geometry.to_triangles(nu=self.nu, nv=self.nv)):
+            vertices.extend([point for point in triangle])
+            faces.append([3 * n, 3 * n + 1, 3 * n + 2])
+        return Mesh.from_vertices_and_faces(vertices, faces)

--- a/src/compas_viewer/scene/nurbssurfaceobject.py
+++ b/src/compas_viewer/scene/nurbssurfaceobject.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from typing import Tuple
 
+from compas.datastructures import Mesh
 from compas.geometry import Line
 from compas.geometry import NurbsSurface
 from compas.geometry import Point
@@ -46,9 +47,6 @@ class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
         return lines
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        surface_points = []
-        for triangle in self.geometry.to_triangles(nu=self.u, nv=self.v):
-            surface_points.append(triangle)
-        return surface_points
+    def viewmesh(self) -> Mesh:
+        """The mesh volume to be shown in the viewer."""
+        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)

--- a/src/compas_viewer/scene/nurbssurfaceobject.py
+++ b/src/compas_viewer/scene/nurbssurfaceobject.py
@@ -21,10 +21,6 @@ class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
         super().__init__(geometry=surface, **kwargs)
         self.geometry: NurbsSurface
 
-        # LINEARDEFLECTION not implemented in NurbsSurface.
-        self.nu = int(16 + (0 * self.LINEARDEFLECTION))
-        self.nv = int(16 + (0 * self.LINEARDEFLECTION))
-
     @property
     def points(self) -> Optional[list[Point]]:
         """The points to be shown in the viewer."""
@@ -48,9 +44,4 @@ class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
     @property
     def viewmesh(self) -> Mesh:
         """The mesh volume to be shown in the viewer."""
-        vertices = []
-        faces = []
-        for n, triangle in enumerate(self.geometry.to_triangles(nu=self.nu, nv=self.nv)):
-            vertices.extend([point for point in triangle])
-            faces.append([3 * n, 3 * n + 1, 3 * n + 2])
-        return Mesh.from_vertices_and_faces(vertices, faces)
+        return self.geometry.to_tesselation()

--- a/src/compas_viewer/scene/nurbssurfaceobject.py
+++ b/src/compas_viewer/scene/nurbssurfaceobject.py
@@ -1,13 +1,15 @@
+from typing import Optional
+from typing import Tuple
+
+from compas.geometry import Line
 from compas.geometry import NurbsSurface
 from compas.geometry import Point
 from compas.scene import GeometryObject
-from compas.utilities import flatten
 
-from .sceneobject import DataType
-from .sceneobject import ViewerSceneObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class NurbsSurfaceObject(ViewerSceneObject, GeometryObject):
+class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS NurbsSurface geometry.
 
     See Also
@@ -17,52 +19,36 @@ class NurbsSurfaceObject(ViewerSceneObject, GeometryObject):
 
     def __init__(self, surface: NurbsSurface, **kwargs):
         super().__init__(geometry=surface, **kwargs)
+        self.geometry: NurbsSurface
 
         # LINEARDEFLECTION not implemented in NurbsSurface.
-        self.u = kwargs.get("u", int(16 + (0 * self.LINEARDEFLECTION)))
-        self.v = kwargs.get("v", int(16 + (0 * self.LINEARDEFLECTION)))
+        self.u = int(16 + (0 * self.LINEARDEFLECTION))
+        self.v = int(16 + (0 * self.LINEARDEFLECTION))
 
-        self._triangles = [list(point) for triangle in surface.to_triangles(nu=self.u, nv=self.v) for point in triangle]
-
-    def _read_points_data(self) -> DataType:
-        positions = [Point(*pt) for pt in flatten(self.geometry.points)]
-        colors = [self.pointscolor.get(i, self.pointscolor["_default"]) for i in range(len(positions))]  # type: ignore
-        elements = [[i] for i in range(len(positions))]
-        return positions, colors, elements
-
-    def _read_lines_data(self) -> DataType:
-        positions = [Point(*pt) for pt in flatten(self.geometry.points)]
-        colors = [self.linescolor.get(i, self.linescolor["_default"]) for i in range(len(positions))]  # type: ignore
-        count = 0
-
-        indexes = []
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        points = []
         for row in self.geometry.points:
-            row_i = []
-            for _ in range(len(row)):
-                row_i.append(count)
-                count += 1
-            indexes.append(row_i)
-        elements = []
-        for row in indexes:
+            points.extend(row)
+        return points
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        lines = []
+        for row in self.geometry.points:
             for i in range(len(row) - 1):
-                elements.append([row[i], row[i + 1]])
-        for col in zip(*indexes):
+                lines.append(Line(row[i], row[i + 1]))
+        for col in zip(*self.geometry.points):
             for i in range(len(col) - 1):
-                elements.append([col[i], col[i + 1]])
-        return positions, colors, elements
+                lines.append(Line(col[i], col[i + 1]))
+        return lines
 
-    def _read_frontfaces_data(self) -> DataType:
-        positions = [Point(*triangle) for triangle in self._triangles]
-        colors = [
-            self.facescolor.get(i, self.facescolor["_default"]) for i in range(len(self._triangles))  # type: ignore
-        ]
-        elements = [[i * 3 + 0, i * 3 + 1, i * 3 + 2] for i in range(int(len(self._triangles) / 3))]
-        return positions, colors, elements
-
-    def _read_backfaces_data(self):
-        positions = self._triangles[::-1]
-        colors = [
-            self.facescolor.get(i, self.facescolor["_default"]) for i in range(len(self._triangles))  # type: ignore
-        ]
-        elements = [[i * 3 + 0, i * 3 + 1, i * 3 + 2] for i in range(int(len(self._triangles) / 3))]
-        return positions, colors, elements
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        surface_points = []
+        for triangle in self.geometry.to_triangles(nu=self.u, nv=self.v):
+            surface_points.append(triangle)
+        return surface_points

--- a/src/compas_viewer/scene/planeobject.py
+++ b/src/compas_viewer/scene/planeobject.py
@@ -42,7 +42,7 @@ class PlaneObject(ViewerGeometryObject, GeometryObject):
     @property
     def points(self) -> Optional[list[Point]]:
         """The points to be shown in the viewer."""
-        pass
+        return None
 
     @property
     def lines(self) -> Optional[list[Line]]:
@@ -56,4 +56,4 @@ class PlaneObject(ViewerGeometryObject, GeometryObject):
     @property
     def viewmesh(self) -> Mesh:
         """The mesh volume to be shown in the viewer."""
-        return Mesh.from_vertices_and_faces(self.vertices, [[0, 1, 2, 3]])
+        return Mesh.from_vertices_and_faces(self.vertices, [[0, 1, 2], [0, 2, 3]])

--- a/src/compas_viewer/scene/planeobject.py
+++ b/src/compas_viewer/scene/planeobject.py
@@ -1,13 +1,16 @@
+from typing import Optional
+from typing import Tuple
+
 from compas.geometry import Frame
+from compas.geometry import Line
 from compas.geometry import Plane
 from compas.geometry import Point
 from compas.scene import GeometryObject
 
-from .sceneobject import DataType
-from .sceneobject import ViewerSceneObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class PlaneObject(ViewerSceneObject, GeometryObject):
+class PlaneObject(ViewerGeometryObject, GeometryObject):
     """
     Viewer scene object for displaying COMPAS Plane geometry.
 
@@ -36,18 +39,24 @@ class PlaneObject(ViewerSceneObject, GeometryObject):
             Point(*self.frame.to_world_coordinates([-self.planesize, self.planesize, 0])),
         ]
 
-    def _read_lines_data(self) -> DataType:
-        positions = [
-            Point(*self.frame.to_world_coordinates([0, 0, 0])),
-            Point(*self.frame.to_world_coordinates([0, 0, self.planesize])),
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        pass
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        return [
+            Line(
+                Point(*self.frame.to_world_coordinates([0, 0, 0])),
+                Point(*self.frame.to_world_coordinates([0, 0, self.planesize])),
+            )
         ]
-        colors = [self.linescolor["_default"], self.linescolor["_default"]]
-        elements = [[0, 1]]
 
-        return positions, colors, elements
-
-    def _read_frontfaces_data(self) -> DataType:
-        return self.vertices, [self.facescolor["_default"]] * 4, [[0, 1, 2], [0, 2, 3]]
-
-    def _read_backfaces_data(self) -> DataType:
-        return self.vertices, [self.facescolor["_default"]] * 4, [[2, 1, 0], [3, 2, 0]]
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        return [
+            (self.vertices[0], self.vertices[1], self.vertices[2]),
+            (self.vertices[0], self.vertices[2], self.vertices[3]),
+        ]

--- a/src/compas_viewer/scene/planeobject.py
+++ b/src/compas_viewer/scene/planeobject.py
@@ -1,6 +1,6 @@
 from typing import Optional
-from typing import Tuple
 
+from compas.datastructures import Mesh
 from compas.geometry import Frame
 from compas.geometry import Line
 from compas.geometry import Plane
@@ -54,9 +54,6 @@ class PlaneObject(ViewerGeometryObject, GeometryObject):
         ]
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        return [
-            (self.vertices[0], self.vertices[1], self.vertices[2]),
-            (self.vertices[0], self.vertices[2], self.vertices[3]),
-        ]
+    def viewmesh(self) -> Mesh:
+        """The mesh volume to be shown in the viewer."""
+        return Mesh.from_vertices_and_faces(self.vertices, [[0, 1, 2, 3]])

--- a/src/compas_viewer/scene/pointobject.py
+++ b/src/compas_viewer/scene/pointobject.py
@@ -36,9 +36,9 @@ class PointObject(ViewerGeometryObject, GeometryObject):
     @property
     def lines(self) -> Optional[list[Line]]:
         """The lines to be shown in the viewer."""
-        pass
+        return None
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        pass
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return None

--- a/src/compas_viewer/scene/pointobject.py
+++ b/src/compas_viewer/scene/pointobject.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from typing import Tuple
 
 from compas.geometry import Line
 from compas.geometry import Point

--- a/src/compas_viewer/scene/pointobject.py
+++ b/src/compas_viewer/scene/pointobject.py
@@ -1,11 +1,14 @@
+from typing import Optional
+from typing import Tuple
+
+from compas.geometry import Line
 from compas.geometry import Point
 from compas.scene import GeometryObject
 
-from .sceneobject import DataType
-from .sceneobject import ViewerSceneObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class PointObject(ViewerSceneObject, GeometryObject):
+class PointObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Point geometry.
 
     Parameters
@@ -21,17 +24,21 @@ class PointObject(ViewerSceneObject, GeometryObject):
     """
 
     def __init__(self, point: Point, **kwargs):
-        if kwargs["show_points"] is None:
-            kwargs["show_points"] = True
         super().__init__(geometry=point, **kwargs)
+        self.show_points = True
         self.geometry: Point
 
-    def _read_points_data(self) -> DataType:
-        positions = [self.geometry]
-        colors = [self.pointscolor["_default"]]
-        elements = [[0]]
-        return positions, colors, elements
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return [self.geometry]
 
-    def _read_lines_data(self):
-        """No line data exist for this geometry, Return None."""
-        return None
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        pass
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        pass

--- a/src/compas_viewer/scene/polygonobject.py
+++ b/src/compas_viewer/scene/polygonobject.py
@@ -1,10 +1,15 @@
-from compas.datastructures import Mesh
+from typing import Optional
+from typing import Tuple
+
+from compas.geometry import Line
+from compas.geometry import Point
 from compas.geometry import Polygon
+from compas.scene import GeometryObject
 
-from .meshobject import MeshObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class PolygonObject(MeshObject):
+class PolygonObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Polygon geometry.
 
     See Also
@@ -13,4 +18,20 @@ class PolygonObject(MeshObject):
     """
 
     def __init__(self, polygon: Polygon, **kwargs):
-        super().__init__(mesh=Mesh.from_shape(polygon), **kwargs)
+        super().__init__(geometry=polygon, **kwargs)
+        self.geometry: Polygon
+        self.show_lines = True
+
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return self.geometry.points
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        return self.geometry.lines
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        pass

--- a/src/compas_viewer/scene/polygonobject.py
+++ b/src/compas_viewer/scene/polygonobject.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from typing import Tuple
 
 from compas.geometry import Line
 from compas.geometry import Point

--- a/src/compas_viewer/scene/polygonobject.py
+++ b/src/compas_viewer/scene/polygonobject.py
@@ -32,6 +32,6 @@ class PolygonObject(ViewerGeometryObject, GeometryObject):
         return self.geometry.lines
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        pass
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return None

--- a/src/compas_viewer/scene/polylineobject.py
+++ b/src/compas_viewer/scene/polylineobject.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from typing import Tuple
 
 from compas.geometry import Line
 from compas.geometry import Point
@@ -33,6 +32,6 @@ class PolylineObject(ViewerGeometryObject, GeometryObject):
         return self.geometry.lines
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        pass
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return None

--- a/src/compas_viewer/scene/polylineobject.py
+++ b/src/compas_viewer/scene/polylineobject.py
@@ -1,12 +1,15 @@
+from typing import Optional
+from typing import Tuple
+
+from compas.geometry import Line
+from compas.geometry import Point
 from compas.geometry import Polyline
 from compas.scene import GeometryObject
-from compas.utilities import pairwise
 
-from .sceneobject import DataType
-from .sceneobject import ViewerSceneObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class PolylineObject(ViewerSceneObject, GeometryObject):
+class PolylineObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Polyline geometry.
 
     See Also
@@ -17,30 +20,19 @@ class PolylineObject(ViewerSceneObject, GeometryObject):
     def __init__(self, polyline: Polyline, **kwargs):
         super().__init__(geometry=polyline, **kwargs)
         self.geometry: Polyline
+        self.show_lines = True
 
-    def _read_points_data(self) -> DataType:
-        positions = [point for point in self.geometry.points]
-        colors = [
-            self.pointscolor.get(i, self.pointscolor["_default"])  # type: ignore
-            for i, _ in enumerate(self.geometry.points)
-        ]
-        elements = [[i] for i in range(len(positions))]
-        return positions, colors, elements
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return self.geometry.points
 
-    def _read_lines_data(self) -> DataType:
-        positions = []
-        colors = []
-        elements = []
-        if self.geometry.is_closed:
-            lines = pairwise(self.geometry.points + [self.geometry.points[0]])
-        else:
-            lines = pairwise(self.geometry.points)
-        count = 0
-        for i, (pt1, pt2) in enumerate(lines):
-            positions.append(pt1)
-            positions.append(pt2)
-            colors.append(self.pointscolor.get(i, self.pointscolor["_default"]))  # type: ignore
-            colors.append(self.pointscolor.get(i, self.pointscolor["_default"]))  # type: ignore
-            elements.append([count, count + 1])
-            count += 2
-        return positions, colors, elements
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        return self.geometry.lines
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        pass

--- a/src/compas_viewer/scene/scene.py
+++ b/src/compas_viewer/scene/scene.py
@@ -65,6 +65,8 @@ class ViewerScene(Scene):
         opacity: Optional[float] = None,
         hide_coplanaredges: Optional[bool] = None,
         use_vertexcolors: Optional[bool] = None,
+        v: int = 16,
+        u: int = 16,
         **kwargs
     ) -> ViewerSceneObject:
         """
@@ -114,6 +116,10 @@ class ViewerScene(Scene):
             Whether to hide the coplanar edges of the mesh.
         use_vertexcolors : bool, optional
             Whether to use vertex color.
+        v : int, optional
+            The number of vertices in the u-direction of non-OCC geometries. Default is 16.
+        u : int, optional
+            The number of vertices in the v-direction of non-OCC geometries. Default is 16.
         **kwargs : dict, optional
             The other possible parameters to be passed to the object.
 
@@ -144,7 +150,9 @@ class ViewerScene(Scene):
             opacity=opacity,
             hide_coplanaredges=hide_coplanaredges,
             use_vertexcolors=use_vertexcolors,
-            **kwargs
+            v=v,
+            u=u,
+            **kwargs,
         )
 
         return sceneobject

--- a/src/compas_viewer/scene/scene.py
+++ b/src/compas_viewer/scene/scene.py
@@ -7,7 +7,6 @@ from compas.colors import Color
 from compas.data import Data
 from compas.scene import Scene
 
-from compas_viewer.configurations import SceneConfig
 from compas_viewer.utilities import instance_colors_generator
 
 from .sceneobject import ViewerSceneObject
@@ -24,25 +23,19 @@ class ViewerScene(Scene):
     ----------
     viewer : :class:`compas_viewer.Viewer`
         The viewer object.
-    config : :class:`compas_viewer.configurations.scene_config.SceneConfig`
-        The configuration object for the scene.
     name : str, optional
         The name of the scene.
+    context : str, optional
+        The context of the scene.
 
     See Also
     --------
     :class:`compas.scene.Scene`
     """
 
-    def __new__(cls, *args, **kwargs):
-        instance = super(ViewerScene, cls).__new__(cls)
-        Scene.viewerinstance = instance  # type: ignore
-        return instance
-
-    def __init__(self, viewer: "Viewer", config: SceneConfig, name=None):
-        super(ViewerScene, self).__init__(name=name)
+    def __init__(self, viewer: "Viewer", name: str, context: str):
+        super(ViewerScene, self).__init__(name=name, context=context)
         self.viewer = viewer
-        self.config = config
 
         #  Primitive
         self.objects: list[ViewerSceneObject]
@@ -61,9 +54,12 @@ class ViewerScene(Scene):
         show_points: Optional[bool] = None,
         show_lines: Optional[bool] = None,
         show_faces: Optional[bool] = None,
-        pointscolor: Optional[Union[Color, dict[Any, Color]]] = None,
-        linescolor: Optional[Union[Color, dict[Any, Color]]] = None,
-        facescolor: Optional[Union[Color, dict[Any, Color]]] = None,
+        pointcolor: Optional[Color] = None,
+        linecolor: Optional[Color] = None,
+        surfacecolor: Optional[Color] = None,
+        vertexcolor: Optional[Union[Color, dict[Any, Color]]] = None,
+        edgecolor: Optional[Union[Color, dict[Any, Color]]] = None,
+        facecolor: Optional[Union[Color, dict[Any, Color]]] = None,
         lineswidth: Optional[float] = None,
         pointssize: Optional[float] = None,
         opacity: Optional[float] = None,
@@ -92,37 +88,32 @@ class ViewerScene(Scene):
             Default to True.
         show_points : bool, optional
             Whether to show points/vertices of the object.
-            It will override the value in the scene config file.
         show_lines : bool, optional
             Whether to show lines/edges of the object.
-            It will override the value in the scene config file.
         show_faces : bool, optional
             Whether to show faces of the object.
-            It will override the value in the scene config file.
-        pointscolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
-            The color or the dict of colors of the points.
-            It will override the value in the scene config file.
-        linescolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
-            The color or the dict of colors of the lines.
-            It will override the value in the scene config file.
-        facescolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
-            The color or the dict of colors the faces.
-            It will override the value in the scene config file.
+        pointcolor : :class:`compas.colors.Color`, optional
+            The single color of colors of the points in the COMPAS Geometry.
+        linecolor : :class:`compas.colors.Color`, optional
+            The single color of colors of the lines in the COMPAS Geometry.
+        surfacecolor : :class:`compas.colors.Color`, optional
+            The single color of colors the surfaces in the COMPAS Geometry.
+        vertexcolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
+            The color or the dict of colors of the vertices in the COMPAS Mesh.
+        edgecolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
+            The color or the dict of colors of the edges in the COMPAS Mesh.
+        facecolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
+            The color or the dict of colors of the faces in the COMPAS Mesh.
         lineswidth : float, optional
             The line width to be drawn on screen
-            It will override the value in the scene config file.
         pointssize : float, optional
             The point size to be drawn on screen
-            It will override the value in the scene config file.
         opacity : float, optional
             The opacity of the object.
-            It will override the value in the scene config file.
         hide_coplanaredges : bool, optional
             Whether to hide the coplanar edges of the mesh.
-            It will override the value in the scene config file.
         use_vertexcolors : bool, optional
             Whether to use vertex color.
-            It will override the value in the scene config file.
         **kwargs : dict, optional
             The other possible parameters to be passed to the object.
 
@@ -142,28 +133,18 @@ class ViewerScene(Scene):
             show_points=show_points,
             show_lines=show_lines,
             show_faces=show_faces,
-            pointscolor=pointscolor,
-            linescolor=linescolor,
-            facescolor=facescolor,
+            pointcolor=pointcolor,
+            linecolor=linecolor,
+            facecolor=facecolor,
+            surfacecolor=surfacecolor,
+            vertexcolor=vertexcolor,
+            edgecolor=edgecolor,
             lineswidth=lineswidth,
             pointssize=pointssize,
             opacity=opacity,
             hide_coplanaredges=hide_coplanaredges,
             use_vertexcolors=use_vertexcolors,
-            config=self.config,
             **kwargs
         )
 
-        if not is_locked:
-            self.instance_colors[sceneobject.instance_color.rgb255] = sceneobject
-
         return sceneobject
-
-    def clear(self, guids: Optional[Union[list[str], list[ViewerSceneObject]]] = None):
-        """Clear the scene."""
-        if guids is None:
-            guids = self.objects
-
-        for obj in guids:
-            self.remove(obj)
-            del obj

--- a/src/compas_viewer/scene/sceneobject.py
+++ b/src/compas_viewer/scene/sceneobject.py
@@ -42,17 +42,17 @@ class ViewerSceneObject(SceneObject):
     is_visible : bool, optional
         Whether to show object. Default is True.
     show_points : bool, optional
-        Whether to show points/vertices of the object. Global settings in the viewer will be used if not specified.
+        Whether to show points/vertices of the object. Default is the value of `show_points` in `viewer.config`.
     show_lines : bool, optional
-        Whether to show lines/edges of the object. Global settings in the viewer will be used if not specified.
+        Whether to show lines/edges of the object. Default is the value of `show_lines` in `viewer.config`.
     show_faces : bool, optional
-        Whether to show faces of the object. Global settings in the viewer will be used if not specified.
+        Whether to show faces of the object. Default is the value of `show_faces` in `viewer.config`.
     lineswidth : float, optional
-        The line width to be drawn on screen. Global settings in the viewer will be used if not specified.
+        The line width to be drawn on screen. Default is the value of `lineswidth` in `viewer.config`.
     pointssize : float, optional
-        The point size to be drawn on screen. Global settings in the viewer will be used if not specified.
+        The point size to be drawn on screen. Default is the value of `pointssize` in `viewer.config`.
     opacity : float, optional
-        The opacity of the object. Global settings in the viewer will be used if not specified.
+        The opacity of the object. Default is the value of `opacity` in `viewer.config`.
     **kwargs : dict, optional
         Additional visualization options for :class:`compas.scene.SceneObject`.
 

--- a/src/compas_viewer/scene/sceneobject.py
+++ b/src/compas_viewer/scene/sceneobject.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
-from typing import Union
 
 from compas.colors import Color
 from compas.geometry import Point
@@ -13,7 +12,7 @@ from numpy import array
 from numpy import average
 from numpy import identity
 
-from compas_viewer.configurations import SceneConfig
+from compas_viewer.components.renderer.shaders import Shader
 from compas_viewer.utilities.gl import make_index_buffer
 from compas_viewer.utilities.gl import make_vertex_buffer
 from compas_viewer.utilities.gl import update_index_buffer
@@ -21,10 +20,10 @@ from compas_viewer.utilities.gl import update_vertex_buffer
 
 if TYPE_CHECKING:
     from compas_viewer import Viewer
-    from compas_viewer.components.renderer.shaders import Shader
+
 
 # Type template of point/line/face data for generating the buffers.
-DataType = tuple[list[Point], list[Color], list[list[int]]]
+ShaderDataType = tuple[list[Point], list[Color], list[list[int]]]
 
 
 class ViewerSceneObject(SceneObject):
@@ -36,40 +35,30 @@ class ViewerSceneObject(SceneObject):
     ----------
     viewer : :class:`compas_viewer.viewer.Viewer`
         The viewer object.
-    is_selected : bool
-        Whether the object is selected.
-    is_locked : bool
-        Whether the object is locked.
-    is_visible : bool
-        Whether to show object.
+    is_selected : bool, optional
+        Whether the object is selected. Default is False.
+    is_locked : bool, optional
+        Whether the object is locked. Default is False.
+    is_visible : bool, optional
+        Whether to show object. Default is True.
     show_points : bool, optional
-        Whether to show points/vertices of the object. It will override the value in the config file.
+        Whether to show points/vertices of the object. Global settings in the viewer will be used if not specified.
     show_lines : bool, optional
-        Whether to show lines/edges of the object. It will override the value in the config file.
+        Whether to show lines/edges of the object. Global settings in the viewer will be used if not specified.
     show_faces : bool, optional
-        Whether to show faces of the object. It will override the value in the config file.
-    pointscolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`]], optional
-        The color or the dict of colors of the points. It will override the value in the config file.
-    linescolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`]], optional
-        The color or the dict of colors of the lines. It will override the value in the config file.
-    facescolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`]], optional
-        The color or the dict of colors the faces. It will override the value in the config file.
+        Whether to show faces of the object. Global settings in the viewer will be used if not specified.
     lineswidth : float, optional
-        The line width to be drawn on screen. It will override the value in the config file.
+        The line width to be drawn on screen. Global settings in the viewer will be used if not specified.
     pointssize : float, optional
-        The point size to be drawn on screen. It will override the value in the config file.
+        The point size to be drawn on screen. Global settings in the viewer will be used if not specified.
     opacity : float, optional
-        The opacity of the object. It will override the value in the config file.
-    config: :class:`compas_viewer.configurations.scene_config.SceneConfig`.
-        The configuration of the scene object. Defaults to None.
-        It should be assigned though the :class:`compas_viewer.viewer.Viewer.add` method.
-        Otherwise a exception will be raised.
+        The opacity of the object. Global settings in the viewer will be used if not specified.
     **kwargs : dict, optional
-        Additional visualization options for specific objects.
+        Additional visualization options for :class:`compas.scene.SceneObject`.
 
     Attributes
     ----------
-    is_selected : bool
+    is_selected : boolA
         Whether the object is selected.
     is_locked : bool
         Whether the object is locked (selectable).
@@ -82,12 +71,6 @@ class ViewerSceneObject(SceneObject):
         Whether to show lines/edges of the object.
     show_faces : bool
         Whether to show faces of the object.
-    pointscolor : dict[Any, :class:`compas.colors.Color`]
-        The color of the points.
-    linescolor : dict[Any, :class:`compas.colors.Color`]
-        The color of the lines.
-    facescolor : dict[Any, :class:`compas.colors.Color`]
-        The color of the faces.
     lineswidth : float
         The line width to be drawn on screen
     pointssize : float
@@ -104,79 +87,43 @@ class ViewerSceneObject(SceneObject):
     See Also
     --------
     :class:`compas.scene.SceneObject`
-
     """
-
-    LINEARDEFLECTION = 0.2
 
     def __init__(
         self,
         viewer: "Viewer",
-        is_selected: bool,
-        is_locked: bool,
-        is_visible: bool,
+        is_selected: bool = False,
+        is_locked: bool = False,
+        is_visible: bool = True,
         show_points: Optional[bool] = None,
         show_lines: Optional[bool] = None,
         show_faces: Optional[bool] = None,
-        pointscolor: Optional[Union[Color, dict[Any, Color]]] = None,
-        linescolor: Optional[Union[Color, dict[Any, Color]]] = None,
-        facescolor: Optional[Union[Color, dict[Any, Color]]] = None,
         lineswidth: Optional[float] = None,
         pointssize: Optional[float] = None,
         opacity: Optional[float] = None,
-        config: Optional[SceneConfig] = None,
         **kwargs,
     ):
-        if config is None:
-            raise ValueError(
-                "No SceneConfig specified for the ViewerSceneObject. "
-                + "Check if the object is added by the function `scene.add`."
-            )
         #  Basic
-        self.config = config
-        super().__init__(config=self.config, **kwargs)
+        super().__init__(**kwargs)
         self.viewer = viewer
         self.scene = viewer.scene
         self.renderer = viewer.renderer
         self.is_visible = is_visible
+        self.show_points = self.viewer.config.show_points if show_points is None else show_points
+        self.show_lines = self.viewer.config.show_lines if show_lines is None else show_lines
+        self.show_faces = self.viewer.config.show_faces if show_faces is None else show_faces
+        self.lineswidth = lineswidth or self.viewer.config.lineswidth
+        self.pointssize = pointssize or self.viewer.config.pointssize
+        self.opacity = opacity or self.viewer.config.opacity
 
         #  Selection
         self._is_locked = is_locked
         self.is_selected = not is_locked and is_selected
         self.instance_color = Color.from_rgb255(*next(self.scene._instance_colors_generator))
+        if not is_locked:
+            self.scene.instance_colors[self.instance_color.rgb255] = self
 
         #  Visual
-        self.show_points = show_points if show_points is not None else self.config.show_points
-        self.show_lines = show_lines if show_lines is not None else self.config.show_lines
-        self.show_faces = show_faces if show_faces is not None else self.config.show_faces
-
-        if pointscolor is None:
-            self.pointscolor = {"_default": self.config.pointscolor}
-        elif isinstance(pointscolor, Color):
-            self.pointscolor = {"_default": pointscolor}
-        else:
-            self.pointscolor = pointscolor
-            self.pointscolor["_default"] = self.config.pointscolor
-
-        if linescolor is None:
-            self.linescolor = {"_default": self.config.linescolor}
-        elif isinstance(linescolor, Color):
-            self.linescolor = {"_default": linescolor}
-        else:
-            self.linescolor = linescolor
-            self.linescolor["_default"] = self.config.linescolor
-
-        if facescolor is None:
-            self.facescolor = {"_default": self.config.facescolor}
-        elif isinstance(facescolor, Color):
-            self.facescolor = {"_default": facescolor}
-        else:
-            self.facescolor = facescolor
-            self.facescolor["_default"] = self.config.facescolor
-
-        self.lineswidth = lineswidth or self.config.lineswidth
-        self.pointssize = pointssize or self.config.pointssize
-        self.opacity = opacity or self.config.opacity
         self.background: bool = False
 
         #  Geometric
@@ -187,14 +134,14 @@ class ViewerSceneObject(SceneObject):
         self._is_collection = False
 
         #  Primitive
-        self._points_data: Optional[DataType] = None
-        self._lines_data: Optional[DataType] = None
-        self._frontfaces_data: Optional[DataType] = None
-        self._backfaces_data: Optional[DataType] = None
-        self._points_buffer: Optional[dict[str, Any]] = None
-        self._lines_buffer: Optional[dict[str, Any]] = None
-        self._frontfaces_buffer: Optional[dict[str, Any]] = None
-        self._backfaces_buffer: Optional[dict[str, Any]] = None
+        self._points_data: Optional[ShaderDataType] = None
+        self._lines_data: Optional[ShaderDataType] = None
+        self._frontfaces_data: Optional[ShaderDataType] = None
+        self._backfaces_data: Optional[ShaderDataType] = None
+        self._points_buffer: [dict[str, Any]] = None  # type: ignore
+        self._lines_buffer: [dict[str, Any]] = None  # type: ignore
+        self._frontfaces_buffer: [dict[str, Any]] = None  # type: ignore
+        self._backfaces_buffer: [dict[str, Any]] = None  # type: ignore
 
     @property
     def is_locked(self):
@@ -221,21 +168,21 @@ class ViewerSceneObject(SceneObject):
     # Reading geometric data, downstream classes should implement these properties.
     # ==========================================================================
 
-    def _read_points_data(self) -> Optional[DataType]:
+    def _read_points_data(self) -> Optional[ShaderDataType]:
         """Read points data from the object."""
-        pass
+        raise NotImplementedError
 
-    def _read_lines_data(self) -> Optional[DataType]:
+    def _read_lines_data(self) -> Optional[ShaderDataType]:
         """Read lines data from the object."""
-        pass
+        raise NotImplementedError
 
-    def _read_frontfaces_data(self) -> Optional[DataType]:
+    def _read_frontfaces_data(self) -> Optional[ShaderDataType]:
         """Read frontfaces data from the object."""
-        pass
+        raise NotImplementedError
 
-    def _read_backfaces_data(self) -> Optional[DataType]:
+    def _read_backfaces_data(self) -> Optional[ShaderDataType]:
         """Read backfaces data from the object."""
-        pass
+        raise NotImplementedError
 
     # ==========================================================================
     # general
@@ -254,7 +201,7 @@ class ViewerSceneObject(SceneObject):
     # buffer
     # ==========================================================================
 
-    def make_buffer_from_data(self, data: DataType) -> dict[str, Any]:
+    def make_buffer_from_data(self, data: ShaderDataType) -> dict[str, Any]:
         """Create buffers from point/line/face data.
 
         Parameters
@@ -277,7 +224,7 @@ class ViewerSceneObject(SceneObject):
 
     def update_buffer_from_data(
         self,
-        data: DataType,
+        data: ShaderDataType,
         buffer: dict[str, Any],
         update_positions: bool,
         update_colors: bool,
@@ -334,17 +281,13 @@ class ViewerSceneObject(SceneObject):
         """Update all buffers from object's data"""
 
         if self._points_data is not None:
-            assert self._points_buffer is not None
             # boolean values are keys for improving the performance, true for now to update all, will flag them later.
             self.update_buffer_from_data(self._points_data, self._points_buffer, True, True, True)
         if self._lines_data is not None:
-            assert self._lines_buffer is not None
             self.update_buffer_from_data(self._lines_data, self._lines_buffer, True, True, True)
         if self._frontfaces_data is not None:
-            assert self._frontfaces_buffer is not None
             self.update_buffer_from_data(self._frontfaces_data, self._frontfaces_buffer, True, True, True)
         if self._backfaces_data is not None:
-            assert self._backfaces_buffer is not None
             self.update_buffer_from_data(self._backfaces_data, self._backfaces_buffer, True, True, True)
 
     def init(self):
@@ -381,34 +324,26 @@ class ViewerSceneObject(SceneObject):
         )
         self._bounding_box_center = Point(*list(average(a=array(self.bounding_box), axis=0)))
 
-    def draw(self, shader: "Shader", wireframe: bool, is_lighted: bool):
+    def draw(self, shader: Shader, wireframe: bool, is_lighted: bool):
         """Draw the object from its buffers"""
-
         shader.enable_attribute("position")
         shader.enable_attribute("color")
         shader.uniform1i("is_selected", self.is_selected)
+        # Matrix
         if self._matrix_buffer is not None:
             shader.uniform4x4("transform", self._matrix_buffer)
         shader.uniform1i("is_lighted", is_lighted)
         shader.uniform1f("object_opacity", self.opacity)
         shader.uniform1i("element_type", 2)
+        # Frontfaces
         if self._frontfaces_buffer is not None and not wireframe:
-            shader.uniform3f("single_color", self.facescolor["_default"].rgb)
-            shader.uniform1i(
-                "use_single_color",
-                not self.facescolor and not self._is_collection and not getattr(self, "use_vertexcolors", False),
-            )
             shader.bind_attribute("position", self._frontfaces_buffer["positions"])
             shader.bind_attribute("color", self._frontfaces_buffer["colors"])
             shader.draw_triangles(
                 elements=self._frontfaces_buffer["elements"], n=self._frontfaces_buffer["n"], background=self.background
             )
+        # Backfaces
         if self._backfaces_buffer is not None and not wireframe:
-            shader.uniform3f("single_color", self.facescolor["_default"].rgb)
-            shader.uniform1i(
-                "use_single_color",
-                not self.facescolor and not self._is_collection and not getattr(self, "use_vertexcolors", False),
-            )
             shader.bind_attribute("position", self._backfaces_buffer["positions"])
             shader.bind_attribute("color", self._backfaces_buffer["colors"])
             shader.draw_triangles(
@@ -416,9 +351,8 @@ class ViewerSceneObject(SceneObject):
             )
         shader.uniform1i("is_lighted", False)
         shader.uniform1i("element_type", 1)
+        # Lines
         if self._lines_buffer is not None:
-            shader.uniform3f("single_color", self.linescolor["_default"].rgb)
-            shader.uniform1i("use_single_color", not self.linescolor and not self._is_collection)
             shader.bind_attribute("position", self._lines_buffer["positions"])
             shader.bind_attribute("color", self._lines_buffer["colors"])
             shader.draw_lines(
@@ -428,9 +362,8 @@ class ViewerSceneObject(SceneObject):
                 background=self.background,
             )
         shader.uniform1i("element_type", 0)
+        # Points
         if self._points_buffer is not None:
-            shader.uniform3f("single_color", self.pointscolor["_default"].rgb)
-            shader.uniform1i("use_single_color", not self.pointscolor and not self._is_collection)
             shader.bind_attribute("position", self._points_buffer["positions"])
             shader.bind_attribute("color", self._points_buffer["colors"])
             shader.draw_points(
@@ -439,7 +372,7 @@ class ViewerSceneObject(SceneObject):
                 n=self._points_buffer["n"],
                 background=self.background,
             )
-
+        # Reset
         shader.uniform1i("is_selected", 0)
         shader.uniform1f("object_opacity", 1)
         if self._matrix_buffer is not None:
@@ -451,13 +384,16 @@ class ViewerSceneObject(SceneObject):
         """Draw the object instance for picking"""
         shader.enable_attribute("position")
         shader.uniform3f("instance_color", self.instance_color.rgb)
+        # Matrix
         if self._matrix_buffer is not None:
             shader.uniform4x4("transform", self._matrix_buffer)
+        # Points
         if self._points_buffer is not None and self.show_points:
             shader.bind_attribute("position", self._points_buffer["positions"])
             shader.draw_points(
                 size=self.pointssize, elements=self._points_buffer["elements"], n=self._points_buffer["n"]
             )
+        # Lines
         if self._lines_buffer is not None and (self.show_lines or wireframe):
             shader.bind_attribute("position", self._lines_buffer["positions"])
             shader.draw_lines(
@@ -465,17 +401,16 @@ class ViewerSceneObject(SceneObject):
                 elements=self._lines_buffer["elements"],
                 n=self._lines_buffer["n"],
             )
+        # Frontfaces
         if self._frontfaces_buffer is not None and not wireframe:
             shader.bind_attribute("position", self._frontfaces_buffer["positions"])
             shader.draw_triangles(elements=self._frontfaces_buffer["elements"], n=self._frontfaces_buffer["n"])
+        # Backfaces
         if self._backfaces_buffer is not None and not wireframe:
             shader.bind_attribute("position", self._backfaces_buffer["positions"])
             shader.draw_triangles(elements=self._backfaces_buffer["elements"], n=self._backfaces_buffer["n"])
+        # Reset
         if self._matrix_buffer is not None:
             shader.uniform4x4("transform", identity(4).flatten())
         shader.uniform3f("instance_color", [0, 0, 0])
         shader.disable_attribute("position")
-
-    def clear(self):
-        """Clear the object"""
-        raise NotImplementedError("clear() method is not implemented.")

--- a/src/compas_viewer/scene/sphereobject.py
+++ b/src/compas_viewer/scene/sphereobject.py
@@ -1,12 +1,16 @@
 from math import pi
+from typing import Optional
+from typing import Tuple
 
-from compas.datastructures import Mesh
+from compas.geometry import Line
+from compas.geometry import Point
 from compas.geometry import Sphere
+from compas.scene import GeometryObject
 
-from .meshobject import MeshObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class SphereObject(MeshObject):
+class SphereObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Sphere geometry.
 
     See Also
@@ -15,6 +19,27 @@ class SphereObject(MeshObject):
     """
 
     def __init__(self, sphere: Sphere, **kwargs):
-        self.u = kwargs.get("u", int(2 * pi * sphere.radius / self.LINEARDEFLECTION))
-        self.v = kwargs.get("v", int(2 * pi * sphere.radius / self.LINEARDEFLECTION))
-        super().__init__(mesh=Mesh.from_shape(sphere, u=self.u, v=self.v), **kwargs)
+        super().__init__(geometry=sphere, **kwargs)
+        self.geometry: Sphere
+        self.u = int(2 * pi * sphere.radius / self.LINEARDEFLECTION)
+        self.v = self.u
+
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        pass
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        pass
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        surface_points = []
+        vertices, faces = self.geometry.to_vertices_and_faces(self.u, self.v, True)
+        for face in faces:
+            face_points = [vertices[i] for i in face]
+            surface_points.append(face_points)
+        return surface_points

--- a/src/compas_viewer/scene/sphereobject.py
+++ b/src/compas_viewer/scene/sphereobject.py
@@ -27,14 +27,14 @@ class SphereObject(ViewerGeometryObject, GeometryObject):
     @property
     def points(self) -> Optional[list[Point]]:
         """The points to be shown in the viewer."""
-        pass
+        return [self.geometry.frame.point]
 
     @property
     def lines(self) -> Optional[list[Line]]:
         """The lines to be shown in the viewer."""
-        pass
+        return None
 
     @property
     def viewmesh(self) -> Mesh:
         """The mesh volume to be shown in the viewer."""
-        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)
+        return Mesh.from_shape(self.geometry, u=self.u, v=self.v, triangulated=True)

--- a/src/compas_viewer/scene/sphereobject.py
+++ b/src/compas_viewer/scene/sphereobject.py
@@ -1,7 +1,7 @@
 from math import pi
 from typing import Optional
-from typing import Tuple
 
+from compas.datastructures import Mesh
 from compas.geometry import Line
 from compas.geometry import Point
 from compas.geometry import Sphere
@@ -35,11 +35,6 @@ class SphereObject(ViewerGeometryObject, GeometryObject):
         pass
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        surface_points = []
-        vertices, faces = self.geometry.to_vertices_and_faces(self.u, self.v, True)
-        for face in faces:
-            face_points = [vertices[i] for i in face]
-            surface_points.append(face_points)
-        return surface_points
+    def viewmesh(self) -> Mesh:
+        """The mesh volume to be shown in the viewer."""
+        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)

--- a/src/compas_viewer/scene/sphereobject.py
+++ b/src/compas_viewer/scene/sphereobject.py
@@ -1,4 +1,3 @@
-from math import pi
 from typing import Optional
 
 from compas.datastructures import Mesh
@@ -21,8 +20,6 @@ class SphereObject(ViewerGeometryObject, GeometryObject):
     def __init__(self, sphere: Sphere, **kwargs):
         super().__init__(geometry=sphere, **kwargs)
         self.geometry: Sphere
-        self.u = int(2 * pi * sphere.radius / self.LINEARDEFLECTION)
-        self.v = self.u
 
     @property
     def points(self) -> Optional[list[Point]]:

--- a/src/compas_viewer/scene/tagobject.py
+++ b/src/compas_viewer/scene/tagobject.py
@@ -201,13 +201,13 @@ class TagObject(ViewerSceneObject, GeometryObject):
         shader.disable_attribute("position")
 
     def _read_points_data(self):
-        pass
+        return None
 
     def _read_lines_data(self):
-        pass
+        return None
 
     def _read_frontfaces_data(self):
-        pass
+        return None
 
     def _read_backfaces_data(self):
-        pass
+        return None

--- a/src/compas_viewer/scene/tagobject.py
+++ b/src/compas_viewer/scene/tagobject.py
@@ -1,7 +1,6 @@
 from os import PathLike
 from os import path
 from typing import Optional
-
 from typing import Union
 
 from compas.colors import Color
@@ -200,3 +199,15 @@ class TagObject(ViewerSceneObject, GeometryObject):
         shader.uniform1i("is_text", 0)
         shader.uniform1f("object_opacity", 1)
         shader.disable_attribute("position")
+
+    def _read_points_data(self):
+        pass
+
+    def _read_lines_data(self):
+        pass
+
+    def _read_frontfaces_data(self):
+        pass
+
+    def _read_backfaces_data(self):
+        pass

--- a/src/compas_viewer/scene/torusobject.py
+++ b/src/compas_viewer/scene/torusobject.py
@@ -1,4 +1,3 @@
-from math import pi
 from typing import Optional
 
 from compas.datastructures import Mesh
@@ -21,8 +20,6 @@ class TorusObject(ViewerGeometryObject, GeometryObject):
     def __init__(self, torus: Torus, **kwargs):
         super().__init__(geometry=torus, **kwargs)
         self.geometry: Torus
-        self.u = int(2 * pi * torus.radius_axis / self.LINEARDEFLECTION)
-        self.v = int(2 * pi * torus.radius_pipe / self.LINEARDEFLECTION)
 
     @property
     def points(self) -> Optional[list[Point]]:

--- a/src/compas_viewer/scene/torusobject.py
+++ b/src/compas_viewer/scene/torusobject.py
@@ -32,9 +32,9 @@ class TorusObject(ViewerGeometryObject, GeometryObject):
     @property
     def lines(self) -> Optional[list[Line]]:
         """The lines to be shown in the viewer."""
-        pass
+        return None
 
     @property
     def viewmesh(self):
         """The mesh volume to be shown in the viewer."""
-        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)
+        return Mesh.from_shape(self.geometry, u=self.u, v=self.v, triangulated=True)

--- a/src/compas_viewer/scene/torusobject.py
+++ b/src/compas_viewer/scene/torusobject.py
@@ -1,12 +1,16 @@
 from math import pi
+from typing import Optional
+from typing import Tuple
 
-from compas.datastructures import Mesh
+from compas.geometry import Line
+from compas.geometry import Point
 from compas.geometry import Torus
+from compas.scene import GeometryObject
 
-from .meshobject import MeshObject
+from .geometryobject import GeometryObject as ViewerGeometryObject
 
 
-class TorusObject(MeshObject):
+class TorusObject(ViewerGeometryObject, GeometryObject):
     """Viewer scene object for displaying COMPAS Torus geometry.
 
     See Also
@@ -15,7 +19,27 @@ class TorusObject(MeshObject):
     """
 
     def __init__(self, torus: Torus, **kwargs):
-        self.u = kwargs.get("u", int(2 * pi * torus.radius_axis / self.LINEARDEFLECTION))
-        self.v = kwargs.get("v", int(2 * pi * torus.radius_pipe / self.LINEARDEFLECTION))
+        super().__init__(geometry=torus, **kwargs)
+        self.geometry: Torus
+        self.u = int(2 * pi * torus.radius_axis / self.LINEARDEFLECTION)
+        self.v = int(2 * pi * torus.radius_pipe / self.LINEARDEFLECTION)
 
-        super().__init__(mesh=Mesh.from_shape(torus, u=self.u, v=self.v), **kwargs)
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return [self.geometry.plane.point]
+
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        pass
+
+    @property
+    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
+        """The surface to be shown in the viewer. Currently only triangles are supported."""
+        surface_points = []
+        vertices, faces = self.geometry.to_vertices_and_faces(self.u, self.v, True)
+        for face in faces:
+            face_points = [vertices[i] for i in face]
+            surface_points.append(face_points)
+        return surface_points

--- a/src/compas_viewer/scene/torusobject.py
+++ b/src/compas_viewer/scene/torusobject.py
@@ -1,7 +1,7 @@
 from math import pi
 from typing import Optional
-from typing import Tuple
 
+from compas.datastructures import Mesh
 from compas.geometry import Line
 from compas.geometry import Point
 from compas.geometry import Torus
@@ -35,11 +35,6 @@ class TorusObject(ViewerGeometryObject, GeometryObject):
         pass
 
     @property
-    def surfaces(self) -> Optional[list[Tuple[Point, Point, Point]]]:
-        """The surface to be shown in the viewer. Currently only triangles are supported."""
-        surface_points = []
-        vertices, faces = self.geometry.to_vertices_and_faces(self.u, self.v, True)
-        for face in faces:
-            face_points = [vertices[i] for i in face]
-            surface_points.append(face_points)
-        return surface_points
+    def viewmesh(self):
+        """The mesh volume to be shown in the viewer."""
+        return Mesh.from_shape(self.geometry, u=self.u, v=self.v)

--- a/src/compas_viewer/scene/vectorobject.py
+++ b/src/compas_viewer/scene/vectorobject.py
@@ -6,7 +6,7 @@ from compas.scene import GeometryObject
 
 from compas_viewer.components.renderer.shaders.shader import Shader
 
-from .sceneobject import DataType
+from .sceneobject import ShaderDataType
 from .sceneobject import ViewerSceneObject
 
 
@@ -45,9 +45,9 @@ class VectorObject(ViewerSceneObject, GeometryObject):
         self.arrow_buffer: dict[str, Any]
         self._lines_buffer: dict[str, Any]
 
-    def _read_lines_data(self) -> DataType:
-        arrow_end = self._anchor + self.geometry * (1 - self.config.vectorsize)
-        arrow_width = self.config.vectorsize * self.config.vectorsize * self.geometry.length
+    def _read_lines_data(self) -> ShaderDataType:
+        arrow_end = self._anchor + self.geometry * (1 - self.viewer.config.vectorsize)
+        arrow_width = self.viewer.config.vectorsize * self.viewer.config.vectorsize * self.geometry.length
         positions = [
             self._anchor,  # Arrow start
             arrow_end,  # Arrow body end
@@ -58,7 +58,7 @@ class VectorObject(ViewerSceneObject, GeometryObject):
             self._anchor + self.geometry,  # Arrow end
         ]
 
-        colors = [self.linescolor["_default"]] * len(positions)
+        colors = [self.linecolor or self.viewer.config.linescolor] * len(positions)
         elements = [[0, 1]]
         return positions, colors, elements
 

--- a/src/compas_viewer/scene/vectorobject.py
+++ b/src/compas_viewer/scene/vectorobject.py
@@ -58,7 +58,7 @@ class VectorObject(ViewerSceneObject, GeometryObject):
             self._anchor + self.geometry,  # Arrow end
         ]
 
-        colors = [self.linecolor or self.viewer.config.linescolor] * len(positions)
+        colors = [self.linecolor or self.viewer.config.linecolor] * len(positions)
         elements = [[0, 1]]
         return positions, colors, elements
 

--- a/src/compas_viewer/viewer.py
+++ b/src/compas_viewer/viewer.py
@@ -15,7 +15,7 @@ from compas_viewer.configurations import ActionConfig
 from compas_viewer.configurations import ControllerConfig
 from compas_viewer.configurations import LayoutConfig
 from compas_viewer.configurations import RendererConfig
-from compas_viewer.configurations import SceneConfig
+from compas_viewer.configurations import ViewerConfig
 from compas_viewer.controller import Controller
 from compas_viewer.layout import Layout
 from compas_viewer.scene.scene import ViewerScene
@@ -90,12 +90,12 @@ class Viewer:
         # Custom or default config
         if configpath is None:
             self.renderer_config = RendererConfig.from_default()
-            self.scene_config = SceneConfig.from_default()
+            self.viewer_config = ViewerConfig.from_default()
             self.controller_config = ControllerConfig.from_default()
             self.layout_config = LayoutConfig.from_default()
         else:
             self.renderer_config = RendererConfig.from_json(Path(configpath, "renderer.json"))
-            self.scene_config = SceneConfig.from_json(Path(configpath, "scene.json"))
+            self.viewer_config = ViewerConfig.from_json(Path(configpath, "scene.json"))
             self.controller_config = ControllerConfig.from_json(Path(configpath, "controller.json"))
             self.layout_config = LayoutConfig.from_json(Path(configpath, "layout.json"))
 
@@ -115,13 +115,13 @@ class Viewer:
         if show_grid is not None:
             self.renderer_config.show_grid = show_grid
 
+        # Viewer
+        self.config = self.viewer_config
+
         #  Application
         self.started = False
         self.app = QCoreApplication.instance() or QApplication(sys.argv)
         self.window = QMainWindow()
-
-        # Viewer
-        self.config = self.scene_config
 
         # Scene
         self.scene = ViewerScene(self, name=self.layout_config.window.title, context="Viewer")

--- a/src/compas_viewer/viewer.py
+++ b/src/compas_viewer/viewer.py
@@ -18,9 +18,9 @@ from compas_viewer.configurations import RendererConfig
 from compas_viewer.configurations import SceneConfig
 from compas_viewer.controller import Controller
 from compas_viewer.layout import Layout
+from compas_viewer.scene.scene import ViewerScene
+from compas_viewer.scene.sceneobject import ViewerSceneObject
 from compas_viewer.utilities import Timer
-
-from .scene import ViewerScene as Scene
 
 
 class Viewer:
@@ -87,9 +87,6 @@ class Viewer:
         show_grid: Optional[bool] = None,
         configpath: Optional[str] = None,
     ):
-
-        self.started = False
-
         # Custom or default config
         if configpath is None:
             self.renderer_config = RendererConfig.from_default()
@@ -119,11 +116,15 @@ class Viewer:
             self.renderer_config.show_grid = show_grid
 
         #  Application
+        self.started = False
         self.app = QCoreApplication.instance() or QApplication(sys.argv)
         self.window = QMainWindow()
 
+        # Viewer
+        self.config = self.scene_config
+
         # Scene
-        self.scene = Scene(self, config=self.scene_config)
+        self.scene = ViewerScene(self, name=self.layout_config.window.title, context="Viewer")
 
         # Controller
         self.controller = Controller(self, self.controller_config)
@@ -139,15 +140,18 @@ class Viewer:
         self.timer: Timer
         self.frame_count: int = 0
 
+        #  Primitive
+        self.objects: list[ViewerSceneObject]
+
     # ==========================================================================
     # Scene
     # ==========================================================================
 
-    def add(self, item, **kwargs):
+    def add(self, **kwargs):
         """
         Add an item to the scene.
         This is a compatibility function for the old version of the viewer.
-        While :func:`compas_viewer.scene.ViewerScene.add` is the recommended way to add an item to the scene.
+        While :func:`compas.scene.Scene.add` is the recommended way to add an item to the scene.
 
         Returns
         -------
@@ -155,7 +159,7 @@ class Viewer:
             The scene object.
         """
 
-        return self.scene.add(item, **kwargs)
+        return self.scene.add(**kwargs)
 
     # ==========================================================================
     # Runtime


### PR DESCRIPTION
Followed by the discussion with @tomvanmele on 6th March, there is the refactor solution of the viewer.

## Major Changes
-   Fully inherent `compas.scene.MeshObject` and `compas.scene.GeometryObject`.
-   Added `ViewerGeometryObject` as the abstract class for all the geometry objects. Other specific geometry objects are inherited from this class.
-   Unify colour naming. variables that control the colours of geometries are `surfacecolor`, `linecolor`, and `pointcolor`, yet variables that control the colours of meshes are `facecolor`, `edgecolor`, and `vertexcolor`.
-   Rename typing allies, resolve #46 .

Updated example files will follow.

