### PR TITLE
comment out rgba code for further inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved typing hints of `CollectionObject`.
 * Changed to the point object is `show_points = True` by default. Refer to [#73](https://github.com/compas-dev/compas_viewer/issues/73).
 * Changed from `super(__t, __obj)` to `super()` as the new version.
+* Temporarily removed `rgba` which is causing blank screen for macos.
 
 ### Removed
 * Removed `utilities` folder.

--- a/src/compas_viewer/components/renderer/shaders/model.frag
+++ b/src/compas_viewer/components/renderer/shaders/model.frag
@@ -10,30 +10,22 @@ uniform bool is_lighted;
 uniform bool is_selected;
 uniform vec3 selection_color;
 uniform int element_type;
-uniform vec3 single_color;
-uniform bool use_single_color;
-uniform bool use_rgba;
+// uniform bool use_rgba;
 
 void main()
 {
     float alpha=opacity*object_opacity;
     vec3 color;
     color=vertex_color;
-    if(is_selected){
-        if(element_type==0){color=selection_color*.9;}
-        else if(element_type==1){color=selection_color*.8;}
-        else{color=selection_color;}
-        if(alpha<.5)alpha=.5;
-    }
     if (is_selected) {
         if (element_type == 0) {color = selection_color*0.9;}
         else if (element_type == 1) {color = selection_color*0.8;}
         else {color = selection_color;}
         if (alpha < 0.5) alpha = 0.5;
     }
-    if (use_rgba){
-        alpha *= vertex_alpha;
-    }
+    // if (use_rgba){
+    //     alpha *= vertex_alpha;
+    // }
 
     vec3 light_pos=vec3(0,0,0);
     if(is_lighted){

--- a/src/compas_viewer/components/renderer/shaders/model.vert
+++ b/src/compas_viewer/components/renderer/shaders/model.vert
@@ -2,20 +2,20 @@
 
 attribute vec3 position;
 attribute vec3 color;
-attribute float alpha;
+// attribute float alpha;
 
 uniform mat4 projection;
 uniform mat4 viewworld;
 uniform mat4 transform;
 
 varying vec3 vertex_color;
-varying float vertex_alpha;
+// varying float vertex_alpha;
 varying vec3 ec_pos;
 
 void main()
 {
     vertex_color = color;
-    vertex_alpha = alpha;
+    // vertex_alpha = alpha;
     gl_Position = projection * viewworld * transform * vec4(position, 1.0);
     ec_pos = vec3(viewworld * transform * vec4(position, 1.0));
     

--- a/src/compas_viewer/scene/sceneobject.py
+++ b/src/compas_viewer/scene/sceneobject.py
@@ -381,12 +381,14 @@ class ViewerSceneObject(SceneObject):
         shader.uniform1i("is_lighted", is_lighted)
         shader.uniform1f("object_opacity", self.opacity)
         shader.uniform1i("element_type", 2)
+        # if self.use_rgba:
+        #     shader.enable_attribute("alpha")
         # Frontfaces
         if self._frontfaces_buffer is not None and not wireframe and self.show_faces:
             shader.bind_attribute("position", self._frontfaces_buffer["positions"])
             shader.bind_attribute("color", self._frontfaces_buffer["colors"])
-            if self.use_rgba and self._frontfaces_buffer.get("opacities") is not None:
-                shader.bind_attribute("alpha", self._frontfaces_buffer["opacities"], step=1)
+            # if self.use_rgba and self._frontfaces_buffer.get("opacities") is not None:
+            #     shader.bind_attribute("alpha", self._frontfaces_buffer["opacities"], step=1)
             shader.draw_triangles(
                 elements=self._frontfaces_buffer["elements"], n=self._frontfaces_buffer["n"], background=self.background
             )
@@ -394,8 +396,8 @@ class ViewerSceneObject(SceneObject):
         if self._backfaces_buffer is not None and not wireframe and self.show_faces:
             shader.bind_attribute("position", self._backfaces_buffer["positions"])
             shader.bind_attribute("color", self._backfaces_buffer["colors"])
-            if self.use_rgba and self._backfaces_buffer.get("opacities") is not None:
-                shader.bind_attribute("alpha", self._backfaces_buffer["opacities"], step=1)
+            # if self.use_rgba and self._backfaces_buffer.get("opacities") is not None:
+            #     shader.bind_attribute("alpha", self._backfaces_buffer["opacities"], step=1)
             shader.draw_triangles(
                 elements=self._backfaces_buffer["elements"], n=self._backfaces_buffer["n"], background=self.background
             )
@@ -429,8 +431,8 @@ class ViewerSceneObject(SceneObject):
             shader.uniform4x4("transform", list(identity(4).flatten()))
         shader.disable_attribute("position")
         shader.disable_attribute("color")
-        if self.use_rgba:
-            shader.disable_attribute("alpha")
+        # if self.use_rgba:
+        #     shader.disable_attribute("alpha")
 
     def draw_instance(self, shader, wireframe: bool):
         """Draw the object instance for picking"""


### PR DESCRIPTION
The reason causing the blank screen on mac, was found at vertex shader Line 18. Where the varing float `vertext_alpha` is assigned from the binded vertex `alpha` attribute. This attribute is not binded also not used when the object's `use_rgba` option is not turned on. This is fine on windows, however on mac, the mere presence of an unbinded attribute appear to be throwing off the vertex shader, even when it is put behind an if condition, perhaps because of compilation issues related to parallelism. 

I'm commenting out these sections, so the basic examples can work. The better way to resolve this is perhaps using vec4 for color values that includes alpha, tho at cost of increasing memory footprint. This will be made from another PR

