### PR TITLE
Fix/rgba

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed to the point object is `show_points = True` by default. Refer to [#73](https://github.com/compas-dev/compas_viewer/issues/73).
 * Changed from `super(__t, __obj)` to `super()` as the new version.
 * Temporarily removed `rgba` which is causing blank screen for macos.
+* Re-enabled `rgba` support by switching to `vec4` for color attributes in shader.
+* Fixed the bug of missing `item` parameter in the `Viewer.add` method.
 
 ### Removed
 * Removed `utilities` folder.

--- a/src/compas_viewer/components/renderer/shaders/arrow.frag
+++ b/src/compas_viewer/components/renderer/shaders/arrow.frag
@@ -1,8 +1,8 @@
 #version 120
 
-varying vec3 vertex_color;
+varying vec4 vertex_color;
 
 void main()
 {
-    gl_FragColor=vec4(vertex_color,1);
+    gl_FragColor=vertex_color;
 }

--- a/src/compas_viewer/components/renderer/shaders/arrow.vert
+++ b/src/compas_viewer/components/renderer/shaders/arrow.vert
@@ -1,16 +1,15 @@
 #version 120
 
 attribute vec3 position;
-attribute vec3 color;
+attribute vec4 color;
 
 uniform mat4 projection;
 uniform mat4 viewworld;
 uniform mat4 transform;
 
-varying vec3 vertex_color;
+varying vec4 vertex_color;
 
-void main()
-{
-    vertex_color=color;
-    gl_Position=projection*viewworld*transform*vec4(position,1.);
+void main() {
+    vertex_color = color;
+    gl_Position = projection * viewworld * transform * vec4(position, 1.);
 }

--- a/src/compas_viewer/components/renderer/shaders/model.frag
+++ b/src/compas_viewer/components/renderer/shaders/model.frag
@@ -10,24 +10,27 @@ uniform bool is_selected;
 uniform vec3 selection_color;
 uniform int element_type;
 
-void main()
-{
-    float alpha=opacity*object_opacity*vertex_color.a;
+void main() {
+    float alpha = opacity * object_opacity * vertex_color.a;
     vec3 color;
-    color=vertex_color.rgb;
-    if (is_selected) {
-        if (element_type == 0) {color = selection_color*0.9;}
-        else if (element_type == 1) {color = selection_color*0.8;}
-        else {color = selection_color;}
-        if (alpha < 0.5) alpha = 0.5;
+    color = vertex_color.rgb;
+    if(is_selected) {
+        if(element_type == 0) {
+            color = selection_color * 0.9;
+        } else if(element_type == 1) {
+            color = selection_color * 0.8;
+        } else {
+            color = selection_color;
+        }
+        if(alpha < 0.5)
+            alpha = 0.5;
     }
 
-    vec3 light_pos=vec3(0,0,0);
-    if(is_lighted){
-        vec3 ec_normal=normalize(cross(dFdx(ec_pos),dFdy(ec_pos)));
-        vec3 L=normalize(-ec_pos);
-        gl_FragColor=vec4(color*dot(ec_normal,L),alpha);
-    }else{
-        gl_FragColor=vec4(color,alpha);
+    if(is_lighted) {
+        vec3 ec_normal = normalize(cross(dFdx(ec_pos), dFdy(ec_pos)));
+        vec3 L = normalize(-ec_pos);
+        gl_FragColor = vec4(color * dot(ec_normal, L), alpha);
+    } else {
+        gl_FragColor = vec4(color, alpha);
     }
 }

--- a/src/compas_viewer/components/renderer/shaders/model.frag
+++ b/src/compas_viewer/components/renderer/shaders/model.frag
@@ -1,7 +1,6 @@
 #version 120
 
-varying vec3 vertex_color;
-varying float vertex_alpha;
+varying vec4 vertex_color;
 varying vec3 ec_pos;
 
 uniform float opacity;
@@ -10,22 +9,18 @@ uniform bool is_lighted;
 uniform bool is_selected;
 uniform vec3 selection_color;
 uniform int element_type;
-// uniform bool use_rgba;
 
 void main()
 {
-    float alpha=opacity*object_opacity;
+    float alpha=opacity*object_opacity*vertex_color.a;
     vec3 color;
-    color=vertex_color;
+    color=vertex_color.rgb;
     if (is_selected) {
         if (element_type == 0) {color = selection_color*0.9;}
         else if (element_type == 1) {color = selection_color*0.8;}
         else {color = selection_color;}
         if (alpha < 0.5) alpha = 0.5;
     }
-    // if (use_rgba){
-    //     alpha *= vertex_alpha;
-    // }
 
     vec3 light_pos=vec3(0,0,0);
     if(is_lighted){

--- a/src/compas_viewer/components/renderer/shaders/model.vert
+++ b/src/compas_viewer/components/renderer/shaders/model.vert
@@ -1,22 +1,19 @@
 #version 120
 
 attribute vec3 position;
-attribute vec3 color;
-// attribute float alpha;
+attribute vec4 color;
 
 uniform mat4 projection;
 uniform mat4 viewworld;
 uniform mat4 transform;
 
-varying vec3 vertex_color;
-// varying float vertex_alpha;
+varying vec4 vertex_color;
 varying vec3 ec_pos;
 
 void main()
 {
     vertex_color = color;
-    // vertex_alpha = alpha;
     gl_Position = projection * viewworld * transform * vec4(position, 1.0);
     ec_pos = vec3(viewworld * transform * vec4(position, 1.0));
-    
+
 }

--- a/src/compas_viewer/components/renderer/shaders/model.vert
+++ b/src/compas_viewer/components/renderer/shaders/model.vert
@@ -10,8 +10,7 @@ uniform mat4 transform;
 varying vec4 vertex_color;
 varying vec3 ec_pos;
 
-void main()
-{
+void main() {
     vertex_color = color;
     gl_Position = projection * viewworld * transform * vec4(position, 1.0);
     ec_pos = vec3(viewworld * transform * vec4(position, 1.0));

--- a/src/compas_viewer/scene/vectorobject.py
+++ b/src/compas_viewer/scene/vectorobject.py
@@ -75,7 +75,7 @@ class VectorObject(ViewerSceneObject, GeometryObject):
         shader.enable_attribute("position")
         shader.enable_attribute("color")
         shader.bind_attribute("position", self._lines_buffer["positions"])
-        shader.bind_attribute("color", self._lines_buffer["colors"])
+        shader.bind_attribute("color", self._lines_buffer["colors"], step=4)
         shader.draw_arrows(
             elements=self._lines_buffer["elements"], n=self._lines_buffer["n"], width=self.lineswidth, background=True
         )

--- a/src/compas_viewer/viewer.py
+++ b/src/compas_viewer/viewer.py
@@ -172,7 +172,7 @@ class Viewer:
             The scene object.
         """
 
-        return self.scene.add(*args, **kwargs)
+        return self.scene.add(item, *args, **kwargs)
 
     # ==========================================================================
     # Runtime


### PR DESCRIPTION
Re-enabling vertex `rgba` support by universally using `vec4` in shaders for color attributes, and always binding them with step size 4. This means we always send in alpha values per vertex, which will increase gpu memory usage for the color buffer by 25%. but seems fine on my tests. Let me know if this create any significant slow down on your machines. 