### PR TITLE
Fix mouse selection flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Temporarily removed `rgba` which is causing blank screen for macos.
 * Re-enabled `rgba` support by switching to `vec4` for color attributes in shader.
 * Fixed the bug of missing `item` parameter in the `Viewer.add` method.
+* Fixed mouse selection flickering issue.
 
 ### Removed
 * Removed `utilities` folder.

--- a/src/compas_viewer/components/renderer/selector.py
+++ b/src/compas_viewer/components/renderer/selector.py
@@ -130,7 +130,7 @@ class Selector(QObject):
         """Drag select the objects in the rectangle area."""
 
         # Ignore drag selection caused by small mouse shift.
-        if abs(self.drag_start_pt.x() - self.drag_end_pt.x()) * abs(self.drag_start_pt.y() - self.drag_end_pt.y()) <=4:
+        if abs(self.drag_start_pt.x() - self.drag_end_pt.x()) * abs(self.drag_start_pt.y() - self.drag_end_pt.y()) <= 4:
             return
 
         # Deselect all objects first

--- a/src/compas_viewer/components/renderer/selector.py
+++ b/src/compas_viewer/components/renderer/selector.py
@@ -129,6 +129,10 @@ class Selector(QObject):
     def drag_selection_action(self):
         """Drag select the objects in the rectangle area."""
 
+        # Ignore drag selection caused by small mouse shift.
+        if abs(self.drag_start_pt.x() - self.drag_end_pt.x()) * abs(self.drag_start_pt.y() - self.drag_end_pt.y()) <=4:
+            return
+
         # Deselect all objects first
         for _, obj in self.renderer.scene.instance_colors.items():
             obj.is_selected = False


### PR DESCRIPTION
Fixing the mouse selection flickering problem #100  that is caused by small mouse drift at release, which falsely triggers a drag selection of 0 pixels, that ends up de-select everything. 

