### PR TITLE
factor out PyOpenGL-accelerate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* removed `PyOpenGL-accelerate` from requirements.txt
+
 ### Removed
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 compas >= 2.0.0
 freetype-py
 PyOpenGL
-PyOpenGL_accelerate
 PySide6 == 6.6.1


### PR DESCRIPTION
this dependency fails to install on macOs and isn't used in the code anywhere.
