### PR TITLE
fix nurbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * removed `PyOpenGL-accelerate` from requirements.txt
+* Changed `NurbsSurfaceObject` to use tessellation function of `OCCBrep`, show boundary curves instead of control curves.
 
 ### Removed
 

--- a/src/compas_viewer/scene/__init__.py
+++ b/src/compas_viewer/scene/__init__.py
@@ -82,7 +82,6 @@ def register_scene_objects():
     register(Ellipse, EllipseObject, context="Viewer")
     register(Cone, ConeObject, context="Viewer")
     register(Capsule, CapsuleObject, context="Viewer")
-    register(NurbsSurface, NurbsSurfaceObject, context="Viewer")
     register(list[Union[Geometry, Mesh]], CollectionObject, context="Viewer")
 
     try:
@@ -90,6 +89,8 @@ def register_scene_objects():
         from .brepobject import BRepObject
 
         register(OCCBrep, BRepObject, context="Viewer")
+        register(NurbsSurface, NurbsSurfaceObject, context="Viewer")
+
     except ImportError:
         pass
 

--- a/src/compas_viewer/scene/__init__.py
+++ b/src/compas_viewer/scene/__init__.py
@@ -46,7 +46,6 @@ from .cylinderobject import CylinderObject
 from .ellipseobject import EllipseObject
 from .coneobject import ConeObject
 from .capsuleobject import CapsuleObject
-from .nurbssurfaceobject import NurbsSurfaceObject
 from .collectionobject import CollectionObject
 from .geometryobject import GeometryObject
 
@@ -87,6 +86,7 @@ def register_scene_objects():
     try:
         from compas_occ.brep import OCCBrep
         from .brepobject import BRepObject
+        from .nurbssurfaceobject import NurbsSurfaceObject
 
         register(OCCBrep, BRepObject, context="Viewer")
         register(NurbsSurface, NurbsSurfaceObject, context="Viewer")

--- a/src/compas_viewer/scene/brepobject.py
+++ b/src/compas_viewer/scene/brepobject.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from compas_occ.brep import OCCBrep
+
 from compas.datastructures import Mesh
 from compas.geometry import Line
 from compas.geometry import Point
@@ -9,48 +11,43 @@ from compas.tolerance import TOL
 
 from .geometryobject import GeometryObject as ViewerGeometryObject
 
-try:
-    from compas_occ.brep import OCCBrep
 
-    class BRepObject(ViewerGeometryObject, GeometryObject):
-        """Viewer scene object for displaying COMPAS OCCBrep geometry.
+class BRepObject(ViewerGeometryObject, GeometryObject):
+    """Viewer scene object for displaying COMPAS OCCBrep geometry.
 
-        Attributes
-        ----------
-        brep : :class:`compas_occ.brep.OCCBrep`
-            The compas_occ Brep object.
-        mesh : :class:`compas.datastructures.Mesh`
-            The mesh representation of the Brep.
+    Attributes
+    ----------
+    brep : :class:`compas_occ.brep.OCCBrep`
+        The compas_occ Brep object.
+    mesh : :class:`compas.datastructures.Mesh`
+        The mesh representation of the Brep.
 
-        See Also
-        --------
-        :class:`compas_occ.brep.Brep`
-        """
+    See Also
+    --------
+    :class:`compas_occ.brep.Brep`
+    """
 
-        def __init__(self, brep: OCCBrep, **kwargs):
-            super().__init__(geometry=brep, **kwargs)
-            self.geometry: OCCBrep
-            self._viewmesh, self._boundaries = self.geometry.to_tesselation(TOL.lineardeflection)
+    def __init__(self, brep: OCCBrep, **kwargs):
+        super().__init__(geometry=brep, **kwargs)
+        self.geometry: OCCBrep
+        self._viewmesh, self._boundaries = self.geometry.to_tesselation(TOL.lineardeflection)
 
-        @property
-        def points(self) -> Optional[list[Point]]:
-            """The points to be shown in the viewer."""
-            return self.geometry.points
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return self.geometry.points
 
-        @property
-        def lines(self) -> Optional[list[Line]]:
-            """The lines to be shown in the viewer."""
-            lines = []
-            for polyline in self._boundaries:
-                for pair in pairwise(polyline.points):
-                    lines.append(Line(*pair))
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        lines = []
+        for polyline in self._boundaries:
+            for pair in pairwise(polyline.points):
+                lines.append(Line(*pair))
 
-            return lines
+        return lines
 
-        @property
-        def viewmesh(self) -> Mesh:
-            """The mesh volume to be shown in the viewer."""
-            return self._viewmesh
-
-except ImportError:
-    pass
+    @property
+    def viewmesh(self) -> Mesh:
+        """The mesh volume to be shown in the viewer."""
+        return self._viewmesh

--- a/src/compas_viewer/scene/brepobject.py
+++ b/src/compas_viewer/scene/brepobject.py
@@ -3,9 +3,9 @@ from typing import Optional
 from compas.datastructures import Mesh
 from compas.geometry import Line
 from compas.geometry import Point
+from compas.itertools import pairwise
 from compas.scene import GeometryObject
 from compas.tolerance import TOL
-from compas.utilities import pairwise
 
 from .geometryobject import GeometryObject as ViewerGeometryObject
 

--- a/src/compas_viewer/scene/nurbssurfaceobject.py
+++ b/src/compas_viewer/scene/nurbssurfaceobject.py
@@ -4,44 +4,48 @@ from compas.datastructures import Mesh
 from compas.geometry import Line
 from compas.geometry import NurbsSurface
 from compas.geometry import Point
+from compas.itertools import pairwise
 from compas.scene import GeometryObject
+from compas.tolerance import TOL
 
 from .geometryobject import GeometryObject as ViewerGeometryObject
 
+try:
+    from compas_occ.brep import OCCBrep
 
-class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
-    """Viewer scene object for displaying COMPAS NurbsSurface geometry.
+    class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
+        """Viewer scene object for displaying COMPAS NurbsSurface geometry.
 
-    See Also
-    --------
-    :class:`compas.geometry.NurbsSurface`
-    """
+        See Also
+        --------
+        :class:`compas.geometry.NurbsSurface`
+        """
 
-    def __init__(self, surface: NurbsSurface, **kwargs):
-        super().__init__(geometry=surface, **kwargs)
-        self.geometry: NurbsSurface
+        def __init__(self, surface: NurbsSurface, **kwargs):
+            super().__init__(geometry=surface, **kwargs)
+            self.geometry: NurbsSurface
+            self._brep: OCCBrep = OCCBrep.from_surface(self.geometry)
+            self._viewmesh, self._boundaries = self._brep.to_tesselation(TOL.lineardeflection)
 
-    @property
-    def points(self) -> Optional[list[Point]]:
-        """The points to be shown in the viewer."""
-        points = []
-        for row in self.geometry.points:
-            points.extend(row)
-        return points
+        @property
+        def points(self) -> Optional[list[Point]]:
+            """The points to be shown in the viewer."""
+            return self._brep.points
 
-    @property
-    def lines(self) -> Optional[list[Line]]:
-        """The lines to be shown in the viewer."""
-        lines = []
-        for row in self.geometry.points:
-            for i in range(len(row) - 1):
-                lines.append(Line(row[i], row[i + 1]))
-        for col in zip(*self.geometry.points):
-            for i in range(len(col) - 1):
-                lines.append(Line(col[i], col[i + 1]))
-        return lines
+        @property
+        def lines(self) -> Optional[list[Line]]:
+            """The lines to be shown in the viewer."""
+            lines = []
+            for polyline in self._boundaries:
+                for pair in pairwise(polyline.points):
+                    lines.append(Line(*pair))
 
-    @property
-    def viewmesh(self) -> Mesh:
-        """The mesh volume to be shown in the viewer."""
-        return self.geometry.to_tesselation()
+            return lines
+
+        @property
+        def viewmesh(self) -> Mesh:
+            """The mesh volume to be shown in the viewer."""
+            return self._viewmesh
+
+except ImportError:
+    pass

--- a/src/compas_viewer/scene/nurbssurfaceobject.py
+++ b/src/compas_viewer/scene/nurbssurfaceobject.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from compas_occ.brep import OCCBrep
+
 from compas.datastructures import Mesh
 from compas.geometry import Line
 from compas.geometry import NurbsSurface
@@ -10,42 +12,37 @@ from compas.tolerance import TOL
 
 from .geometryobject import GeometryObject as ViewerGeometryObject
 
-try:
-    from compas_occ.brep import OCCBrep
 
-    class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
-        """Viewer scene object for displaying COMPAS NurbsSurface geometry.
+class NurbsSurfaceObject(ViewerGeometryObject, GeometryObject):
+    """Viewer scene object for displaying COMPAS NurbsSurface geometry.
 
-        See Also
-        --------
-        :class:`compas.geometry.NurbsSurface`
-        """
+    See Also
+    --------
+    :class:`compas.geometry.NurbsSurface`
+    """
 
-        def __init__(self, surface: NurbsSurface, **kwargs):
-            super().__init__(geometry=surface, **kwargs)
-            self.geometry: NurbsSurface
-            self._brep: OCCBrep = OCCBrep.from_surface(self.geometry)
-            self._viewmesh, self._boundaries = self._brep.to_tesselation(TOL.lineardeflection)
+    def __init__(self, surface: NurbsSurface, **kwargs):
+        super().__init__(geometry=surface, **kwargs)
+        self.geometry: NurbsSurface
+        self._brep: OCCBrep = OCCBrep.from_surface(self.geometry)
+        self._viewmesh, self._boundaries = self._brep.to_tesselation(TOL.lineardeflection)
 
-        @property
-        def points(self) -> Optional[list[Point]]:
-            """The points to be shown in the viewer."""
-            return self._brep.points
+    @property
+    def points(self) -> Optional[list[Point]]:
+        """The points to be shown in the viewer."""
+        return self._brep.points
 
-        @property
-        def lines(self) -> Optional[list[Line]]:
-            """The lines to be shown in the viewer."""
-            lines = []
-            for polyline in self._boundaries:
-                for pair in pairwise(polyline.points):
-                    lines.append(Line(*pair))
+    @property
+    def lines(self) -> Optional[list[Line]]:
+        """The lines to be shown in the viewer."""
+        lines = []
+        for polyline in self._boundaries:
+            for pair in pairwise(polyline.points):
+                lines.append(Line(*pair))
 
-            return lines
+        return lines
 
-        @property
-        def viewmesh(self) -> Mesh:
-            """The mesh volume to be shown in the viewer."""
-            return self._viewmesh
-
-except ImportError:
-    pass
+    @property
+    def viewmesh(self) -> Mesh:
+        """The mesh volume to be shown in the viewer."""
+        return self._viewmesh


### PR DESCRIPTION
Convert Nurbs for Brep for tesslation, should get rid of the issue #116 .

Another thought is that shouldn't the edges/lines of the geometry refer to its boundaries rather than the skeleton cage?

Before:
![image](https://github.com/compas-dev/compas_viewer/assets/17893605/1efe3727-1f78-4f4c-88ac-709ed304b9f4)

Now:
![image](https://github.com/compas-dev/compas_viewer/assets/17893605/446e3993-0eec-4ee4-b974-1d7f70dc839d)
