### PR TITLE
scene loading etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Fixed `action` bug.
+* Updated `compas_viewer.scene.ViewerScene` to support save/load and switching.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed `action` bug.
 * Updated `compas_viewer.scene.ViewerScene` to support save/load and switching.
+* Changed `is_visible` parameters to `show` in `compas_viewer.scene.ViewerSceneObject` classes.
 
 ### Removed
 

--- a/scripts/saveload.py
+++ b/scripts/saveload.py
@@ -1,0 +1,52 @@
+import compas
+from compas.colors import Color
+from compas.datastructures import Mesh
+from compas.geometry import Box
+from compas.geometry import Frame
+from compas_viewer.viewer import Viewer
+from compas.data import json_dump
+from compas.data import json_load
+from compas.scene import Scene
+
+# Save and load a scene
+viewer = Viewer()
+mesh = Mesh.from_off(compas.get("tubemesh.off"))
+obj = viewer.scene.add(mesh, show_points=True, facecolor=Color.blue(), linecolor=Color.red(), pointcolor=Color.green())
+for i in range(5):
+    for j in range(5):
+        viewer.scene.add(
+            Box(0.5, 0.5, 0.5, Frame([i, j, 0], [1, 0, 0], [0, 1, 0])),
+            show_points=True,
+            linecolor=Color.white(),
+            pointcolor=Color.black(),
+            pointsize=10,
+            facecolor=Color(i / 10, j / 10, 0.0),
+            name=f"Box_{i}_{j}",
+        )
+
+json_dump(viewer.scene, "temp/scene1.json")
+viewer.show()
+
+
+viewer.scene = json_load("temp/scene1.json")
+viewer.show()
+
+
+
+# Viewer with a generic scene
+# Note the generic scene can be more limited in visualization options
+# depending on what's available in the compas.scene.SceneObject classes
+
+scene = Scene()
+mesh = Mesh.from_off(compas.get("tubemesh.off"))
+scene.add(mesh)
+for i in range(5):
+    for j in range(5):
+        scene.add(
+            Box(0.5, 0.5, 0.5, Frame([i, j, 0], [1, 0, 0], [0, 1, 0])),
+            name=f"Box_{i}_{j}",
+        )
+
+viewer = Viewer()
+viewer.scene = scene
+viewer.show()

--- a/scripts/scene.py
+++ b/scripts/scene.py
@@ -8,7 +8,7 @@ from compas.data import json_dump
 from compas.data import json_load
 from compas.scene import Scene
 
-# Save and load a scene
+
 viewer = Viewer()
 mesh = Mesh.from_off(compas.get("tubemesh.off"))
 obj = viewer.scene.add(mesh, show_points=True, facecolor=Color.blue(), linecolor=Color.red(), pointcolor=Color.green())
@@ -24,16 +24,18 @@ for i in range(5):
             name=f"Box_{i}_{j}",
         )
 
-json_dump(viewer.scene, "temp/scene1.json")
+# Save a scene to a file
+json_dump(viewer.scene, "temp/scene.json")
 viewer.show()
 
 
-viewer.scene = json_load("temp/scene1.json")
+# Load a scene from a file
+viewer.scene = json_load("temp/scene.json")
 viewer.show()
 
 
 
-# Viewer with a generic scene
+# Using a generic scene
 # Note the generic scene can be more limited in visualization options
 # depending on what's available in the compas.scene.SceneObject classes
 

--- a/src/compas_viewer/actions/select_all.py
+++ b/src/compas_viewer/actions/select_all.py
@@ -6,6 +6,6 @@ class SelectAll(Action):
 
     def pressed_action(self):
         for obj in self.viewer.scene.objects:
-            if obj.is_visible and not obj.is_locked:
+            if obj.show and not obj.is_locked:
                 obj.is_selected = True
         self.viewer.renderer.update()

--- a/src/compas_viewer/renderer/renderer.py
+++ b/src/compas_viewer/renderer/renderer.py
@@ -408,7 +408,7 @@ class Renderer(QOpenGLWidget, Base):
             show_framez=self.config.renderer.show_gridz,
             is_selected=False,
             is_locked=True,
-            is_visible=self.config.renderer.show_grid,
+            show=self.config.renderer.show_grid,
         )
         self.grid.init()  # type: ignore
 
@@ -596,7 +596,7 @@ class Renderer(QOpenGLWidget, Base):
         viewworld = self.camera.viewworld()
         self.update_projection()
         # Object categorization
-        tag_objs, vector_objs, mesh_objs = self.sort_objects_from_category((obj for obj in self.viewer.scene.objects if obj.is_visible))
+        tag_objs, vector_objs, mesh_objs = self.sort_objects_from_category((obj for obj in self.viewer.scene.objects if obj.show))
 
         # Draw model objects in the scene
         self.shader_model.bind()

--- a/src/compas_viewer/renderer/renderer.py
+++ b/src/compas_viewer/renderer/renderer.py
@@ -192,8 +192,8 @@ class Renderer(QOpenGLWidget, Base):
         * https://doc.qt.io/qtforpython-6/PySide6/QtOpenGL/QOpenGLWindow.html#PySide6.QtOpenGL.PySide6.QtOpenGL.QOpenGLWindow.resizeGL
 
         """
-        self.viewer.config.window.width = w
-        self.viewer.config.window.height = h
+        w = self.viewer.config.window.width
+        h = self.viewer.config.window.height
         GL.glViewport(0, 0, w, h)
         self.resize(w, h)
 

--- a/src/compas_viewer/scene/groupobject.py
+++ b/src/compas_viewer/scene/groupobject.py
@@ -20,7 +20,7 @@ class GroupObject(SceneObject):
 
     def __init__(self, items, **kwargs):
         super().__init__(Group(items), **kwargs)
-        self.is_visible = True
+        self.show = True
         self.is_selected = False
         self.opacity = 1.0
         self.bounding_box = None

--- a/src/compas_viewer/scene/scene.py
+++ b/src/compas_viewer/scene/scene.py
@@ -75,20 +75,19 @@ class ViewerScene(Scene):
         self.instance_colors: dict[tuple[int, int, int], ViewerSceneObject] = {}
         self._instance_colors_generator = instance_colors_generator()
 
+    # TODO: These fixed kwargs could be moved to COMPAS core.
     def add(
         self,
         item: Union[Geometry, Datastructure, ViewerSceneObject],
         parent: Optional[ViewerSceneObject] = None,
         is_selected: bool = False,
         is_locked: bool = False,
-        is_visible: bool = True,
+        show: bool = True,
         show_points: Optional[bool] = None,
         show_lines: Optional[bool] = None,
         show_faces: Optional[bool] = None,
-        pointcolor: Optional[Color] = None,
-        linecolor: Optional[Color] = None,
-        vertexcolor: Optional[Union[Color, dict[Any, Color]]] = None,
-        edgecolor: Optional[Union[Color, dict[Any, Color]]] = None,
+        pointcolor: Optional[Union[Color, dict[Any, Color]]] = None,
+        linecolor: Optional[Union[Color, dict[Any, Color]]] = None,
         facecolor: Optional[Union[Color, dict[Any, Color]]] = None,
         linewidth: Optional[float] = None,
         pointsize: Optional[float] = None,
@@ -116,7 +115,7 @@ class ViewerScene(Scene):
         is_locked : bool, optional
             Whether the object is locked (not selectable).
             Default to False.
-        is_visible : bool, optional
+        show : bool, optional
             Whether to show object.
             Default to True.
         show_points : bool, optional
@@ -125,16 +124,12 @@ class ViewerScene(Scene):
             Whether to show lines/edges of the object.
         show_faces : bool, optional
             Whether to show faces of the object.
-        pointcolor : :class:`compas.colors.Color`, optional
-            The single color of colors of the points in the COMPAS Geometry.
-        linecolor : :class:`compas.colors.Color`, optional
-            The single color of colors of the lines in the COMPAS Geometry.
-        vertexcolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
-            The color or the dict of colors of the vertices in the COMPAS Mesh.
-        edgecolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
-            The color or the dict of colors of the edges in the COMPAS Mesh.
+        pointcolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
+            The color or the dict of colors of the points/vertices of object.
+        linecolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
+            The color or the dict of colors of the lines/edges of object.
         facecolor : Union[:class:`compas.colors.Color`, dict[Any, :class:`compas.colors.Color`], optional
-            The color or the dict of colors of the faces in the COMPAS Mesh.
+            The color or the dict of colors of the faces of object.
         linewidth : float, optional
             The line width to be drawn on screen
         pointsize : float, optional
@@ -162,7 +157,7 @@ class ViewerScene(Scene):
             item=item,
             parent=parent,
             is_selected=is_selected,
-            is_visible=is_visible,
+            show=show,
             is_locked=is_locked,
             show_points=show_points,
             show_lines=show_lines,
@@ -170,8 +165,6 @@ class ViewerScene(Scene):
             pointcolor=pointcolor,
             linecolor=linecolor,
             facecolor=facecolor,
-            vertexcolor=vertexcolor,
-            edgecolor=edgecolor,
             linewidth=linewidth,
             pointsize=pointsize,
             opacity=opacity,

--- a/src/compas_viewer/scene/sceneobject.py
+++ b/src/compas_viewer/scene/sceneobject.py
@@ -450,6 +450,7 @@ class ViewerSceneObject(SceneObject, Base):
     @property
     def settings(self):
         settings = {
+            "name": self.name,
             "is_selected": self.is_selected,
             "is_locked": self.is_locked,
             "show": self.show,

--- a/src/compas_viewer/scene/sceneobject.py
+++ b/src/compas_viewer/scene/sceneobject.py
@@ -6,6 +6,7 @@ from numpy import average
 from numpy import identity
 
 from compas.colors import Color
+from compas.colors import ColorDict
 from compas.geometry import Point
 from compas.geometry import Transformation
 from compas.geometry import transform_points_numpy
@@ -35,7 +36,7 @@ class ViewerSceneObject(SceneObject, Base):
         Whether the object is selected. Default is False.
     is_locked : bool, optional
         Whether the object is locked. Default is False.
-    is_visible : bool, optional
+    show : bool, optional
         Whether to show object. Default is True.
     show_points : bool, optional
         Whether to show points/vertices of the object. Default is the value of `show_points` in `viewer.config`.
@@ -59,7 +60,7 @@ class ViewerSceneObject(SceneObject, Base):
     is_locked : bool
         Whether the object is locked (selectable).
         The global grid is a typical object that is not selectable.
-    is_visible : bool
+    show : bool
         Whether to show object.
     show_points : bool
         Whether to show points/vertices of the object.
@@ -89,7 +90,7 @@ class ViewerSceneObject(SceneObject, Base):
         self,
         is_selected: bool = False,
         is_locked: bool = False,
-        is_visible: bool = True,
+        show: bool = True,
         show_points: Optional[bool] = None,
         show_lines: Optional[bool] = None,
         show_faces: Optional[bool] = None,
@@ -101,7 +102,7 @@ class ViewerSceneObject(SceneObject, Base):
     ):
         #  Basic
         super().__init__(**kwargs)
-        self.is_visible = is_visible
+        self.show = show
         self.show_points = show_points if show_points is not None else False
         self.show_lines = show_lines if show_lines is not None else True
         self.show_faces = show_faces if show_faces is not None else True
@@ -112,10 +113,6 @@ class ViewerSceneObject(SceneObject, Base):
         #  Selection
         self._is_locked = is_locked
         self.is_selected = not is_locked and is_selected
-        # TODO scene
-        self.instance_color = Color.from_rgb255(*next(self.viewer.scene._instance_colors_generator))
-        if not is_locked:
-            self.viewer.scene.instance_colors[self.instance_color.rgb255] = self
 
         #  Visual
         self.background: bool = False
@@ -288,6 +285,8 @@ class ViewerSceneObject(SceneObject, Base):
         self._backfaces_data = self._read_backfaces_data()
         self.make_buffers()
         self._update_matrix()
+        self.instance_color = Color.from_rgb255(*next(self.viewer.scene._instance_colors_generator))
+        self.scene.instance_colors[self.instance_color.rgb255] = self
 
     def update(self, update_positions: bool = True, update_colors: bool = True, update_elements: bool = True):
         """Update the object.
@@ -447,3 +446,39 @@ class ViewerSceneObject(SceneObject, Base):
             shader.uniform4x4("transform", identity(4).flatten())
         shader.uniform3f("instance_color", [0, 0, 0])
         shader.disable_attribute("position")
+
+    @property
+    def settings(self):
+        settings = {
+            "is_selected": self.is_selected,
+            "is_locked": self.is_locked,
+            "show": self.show,
+            "show_points": self.show_points,
+            "show_lines": self.show_lines,
+            "show_faces": self.show_faces,
+            "linewidth": self.linewidth,
+            "pointsize": self.pointsize,
+            "opacity": self.opacity,
+            "background": self.background,
+        }
+
+        # TODO: make ColorDict serializable in compas core.
+        if hasattr(self, "pointcolor"):
+            if isinstance(self.pointcolor, Color):
+                settings["pointcolor"] = self.pointcolor
+            elif isinstance(self.pointcolor, ColorDict):
+                settings["pointcolor"] = self.pointcolor.default
+
+        if hasattr(self, "linecolor"):
+            if isinstance(self.linecolor, Color):
+                settings["linecolor"] = self.linecolor
+            elif isinstance(self.linecolor, ColorDict):
+                settings["linecolor"] = self.linecolor.default
+
+        if hasattr(self, "facecolor"):
+            if isinstance(self.facecolor, Color):
+                settings["facecolor"] = self.facecolor
+            elif isinstance(self.facecolor, ColorDict):
+                settings["facecolor"] = self.facecolor.default
+
+        return settings

--- a/src/compas_viewer/ui/menubar.py
+++ b/src/compas_viewer/ui/menubar.py
@@ -14,6 +14,7 @@ class MenuBar(Base):
 
     def lazy_init(self):
         self.widget = self.viewer.ui.window.menuBar()
+        self.widget.clear()
         self.add_menu(items=self.viewer.config.ui.menubar.items, parent=self.widget)
 
     def add_menu(self, *, items, parent):

--- a/src/compas_viewer/ui/statusbar.py
+++ b/src/compas_viewer/ui/statusbar.py
@@ -4,10 +4,12 @@ from compas_viewer.components.widget_tools import LabelWidget
 
 class SatusBar(Base):
     def __init__(self) -> None:
-        self.label = LabelWidget()
+        self.label = None
         self.widget = None
 
     def lazy_init(self):
         self.widget = self.viewer.ui.window.statusBar()
         self.widget.setHidden(not self.viewer.config.ui.statusbar.show)
-        self.widget.addWidget(self.label(text="Ready..."))
+        if not self.label:
+            self.label = LabelWidget()
+            self.widget.addWidget(self.label(text="Ready..."))

--- a/src/compas_viewer/ui/toolbar.py
+++ b/src/compas_viewer/ui/toolbar.py
@@ -14,7 +14,9 @@ class ToolBar(Base):
         self.widget = None
 
     def lazy_init(self):
-        self.widget = self.viewer.ui.window.addToolBar("Tools")
+        if not self.widget:
+            self.widget = self.viewer.ui.window.addToolBar("Tools")
+        self.widget.clear()
         self.widget.setMovable(False)
         self.widget.setObjectName("Tools")
         self.widget.setHidden(not self.viewer.config.ui.toolbar.show)

--- a/src/compas_viewer/ui/ui.py
+++ b/src/compas_viewer/ui/ui.py
@@ -18,10 +18,6 @@ class UI(Base):
         self.sidedock = SideDock()
 
     def lazy_init(self):
-        width = self.viewer.config.window.width
-        height = self.viewer.config.window.height
-
-        self.resize(width, height)
         self.window.lazy_init()
         self.menubar.lazy_init()
         self.statusbar.lazy_init()
@@ -30,6 +26,7 @@ class UI(Base):
         self.sidedock.lazy_init()
 
     def show(self):
+        self.resize(self.viewer.config.window.width, self.viewer.config.window.height)
         self.window.show()
 
     def resize(self, w: int, h: int) -> None:

--- a/src/compas_viewer/viewer.py
+++ b/src/compas_viewer/viewer.py
@@ -7,6 +7,7 @@ from PySide6.QtCore import QTimer
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QApplication
 
+from compas.scene import Scene
 from compas_viewer import HERE
 from compas_viewer.config import Config
 from compas_viewer.controller import Controller
@@ -27,7 +28,6 @@ class Viewer(Singleton):
         self.timer = QTimer()
 
         self.config = config or Config()
-        self.scene = ViewerScene()
 
         # otherwise this results in a circular import
         # both of these should be removed from this __init__
@@ -37,6 +37,17 @@ class Viewer(Singleton):
         self.controller = Controller(self.config)
 
         self.ui = UI()
+        self._scene = None
+
+    @property
+    def scene(self) -> ViewerScene:
+        if self._scene is None:
+            self._scene = ViewerScene()
+        return self._scene
+
+    @scene.setter
+    def scene(self, scene: Scene):
+        self._scene = ViewerScene.__from_data__(scene.__data__)
 
     def show(self):
         # none of these lazy inits should be necessary


### PR DESCRIPTION
Plz see example at `scripts/scene.py`
- Allowing saving and loading scene.
- Allowing switching to a generic `Scene` from other contexts.


There is several additional changes:
- Changed all `is_visible` parameter in `SceneObjects` to `show` , aligning with compas core.
- Removed `vertex_color`, `edge_color` kwargs in `ViewerScene` 
- Adjusted some UI elements so that when `viewer.show` is called multiple times, the UI elements are not duplicated.