### PR TITLE
add render scale and unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `compas_viewer.render.Render.scale` to efficiently scale the scene.
+* Added `compas_viewer.Viewer.unit` to automatically choose appropriate scale.
+
 ### Changed
 
 ### Removed

--- a/scripts/render_scale.py
+++ b/scripts/render_scale.py
@@ -8,13 +8,15 @@ viewer = Viewer()
 
 for i in range(5):
     for j in range(5):
-        viewer.scene.add(
-            Box(0.5, 0.5, 0.5, Frame([i, j, 0], [1, 0, 0], [0, 1, 0])),
+        obj = viewer.scene.add(
+            Box(0.5, 0.5, 0.5),
             show_points=True,
             show_lines=True,
             surfacecolor=Color(i / 10, j / 10, 0.0),
             name=f"Box_{i}_{j}",
         )
+
+        obj.transformation =  Frame([i, j, 0], [1, 0, 0], [0, 1, 0]).to_transformation()
 
 
 def update_renderscale(slider: Slider, value: int):

--- a/scripts/render_scale.py
+++ b/scripts/render_scale.py
@@ -1,0 +1,29 @@
+from compas.colors import Color
+from compas.geometry import Box
+from compas.geometry import Frame
+from compas_viewer.viewer import Viewer
+from compas_viewer.components import Slider
+
+viewer = Viewer()
+
+for i in range(5):
+    for j in range(5):
+        viewer.scene.add(
+            Box(0.5, 0.5, 0.5, Frame([i, j, 0], [1, 0, 0], [0, 1, 0])),
+            show_points=True,
+            show_lines=True,
+            surfacecolor=Color(i / 10, j / 10, 0.0),
+            name=f"Box_{i}_{j}",
+        )
+
+
+def update_renderscale(slider: Slider, value: int):
+    viewer.renderer.scale = value
+    viewer.renderer.update()
+    print(viewer.renderer.scale)
+
+
+viewer.ui.sidedock.show = True
+viewer.ui.sidedock.add(Slider(title="Render Scale", min_val=1, max_val=100, step=1, action=update_renderscale))
+
+viewer.show()

--- a/scripts/unit.py
+++ b/scripts/unit.py
@@ -1,0 +1,18 @@
+from compas.colors import Color
+from compas.geometry import Box
+from compas.geometry import Frame
+from compas_viewer.viewer import Viewer
+
+viewer = Viewer()
+viewer.unit = "mm"
+
+for i in range(10):
+    for j in range(10):
+        viewer.scene.add(
+            Box(500, 500, 500, Frame([i * 1000, j * 1000, 0], [1, 0, 0], [0, 1, 0])),
+            show_lines=True,
+            surfacecolor=Color(i / 10, j / 10, 0.0),
+            name=f"Box_{i}_{j}",
+        )
+
+viewer.show()

--- a/src/compas_viewer/commands.py
+++ b/src/compas_viewer/commands.py
@@ -196,8 +196,8 @@ def zoom_selected(viewer: "Viewer"):
         return
 
     extents = extents.reshape(-1, 3)
-    max_corner = extents.max(axis=0)
-    min_corner = extents.min(axis=0)
+    max_corner = extents.max(axis=0) * viewer.renderer.scale
+    min_corner = extents.min(axis=0) * viewer.renderer.scale
     viewer.renderer.camera.scale = float((norm(max_corner - min_corner)) / 10)  # 10 is a tuned magic number
     center = (max_corner + min_corner) / 2
     distance = max(norm(max_corner - min_corner), 1)

--- a/src/compas_viewer/renderer/renderer.py
+++ b/src/compas_viewer/renderer/renderer.py
@@ -62,6 +62,7 @@ class Renderer(QOpenGLWidget):
         self._now = time.time()
 
         self.grid = None
+        self.scale = 1.0
 
         self.shader_model: Shader = None
         self.shader_tag: Shader = None
@@ -581,7 +582,9 @@ class Renderer(QOpenGLWidget):
         self.shader_model.bind()
         self.shader_model.uniform4x4("viewworld", viewworld)
         if self.grid is not None:
+            self.shader_model.uniform1f("scale", 1.0)  # grid does not scale
             self.grid.draw(self.shader_model)
+        self.shader_model.uniform1f("scale", self.scale)
         for obj in self.sort_objects_from_viewworld(mesh_objs, viewworld):
             obj.draw(self.shader_model, self.rendermode == "wireframe", self.rendermode == "lighted")
         self.shader_model.release()
@@ -589,6 +592,7 @@ class Renderer(QOpenGLWidget):
         # Draw vector arrows
         self.shader_arrow.bind()
         self.shader_arrow.uniform4x4("viewworld", viewworld)
+        self.shader_arrow.uniform1f("scale", self.scale)
         for obj in vector_objs:
             obj.draw(self.shader_arrow)
         self.shader_arrow.release()
@@ -596,6 +600,7 @@ class Renderer(QOpenGLWidget):
         # Draw text tag sprites
         self.shader_tag.bind()
         self.shader_tag.uniform4x4("viewworld", viewworld)
+        self.shader_tag.uniform1f("scale", self.scale)
         for obj in tag_objs:
             obj.draw(self.shader_tag, self.camera.position)
         self.shader_tag.release()
@@ -636,6 +641,7 @@ class Renderer(QOpenGLWidget):
 
         self.shader_instance.bind()
         self.shader_instance.uniform4x4("viewworld", viewworld)
+        self.shader_instance.uniform1f("scale", self.scale)
         for obj in mesh_objs:
             obj.draw_instance(self.shader_instance, self.rendermode == "wireframe")
         self.shader_instance.release()

--- a/src/compas_viewer/renderer/shaders/arrow.vert
+++ b/src/compas_viewer/renderer/shaders/arrow.vert
@@ -6,10 +6,11 @@ attribute vec4 color;
 uniform mat4 projection;
 uniform mat4 viewworld;
 uniform mat4 transform;
+uniform float scale;
 
 varying vec4 vertex_color;
 
 void main() {
     vertex_color = color;
-    gl_Position = projection * viewworld * transform * vec4(position, 1.);
+    gl_Position = projection * viewworld * transform * vec4(position * scale, 1.);
 }

--- a/src/compas_viewer/renderer/shaders/arrow.vert
+++ b/src/compas_viewer/renderer/shaders/arrow.vert
@@ -12,5 +12,18 @@ varying vec4 vertex_color;
 
 void main() {
     vertex_color = color;
-    gl_Position = projection * viewworld * transform * vec4(position * scale, 1.);
+
+    // Create the scaling matrix
+    mat4 scalingMatrix = mat4(scale, 0.0, 0.0, 0.0, 0.0, scale, 0.0, 0.0, 0.0, 0.0, scale, 0.0, 0.0, 0.0, 0.0, 1.0);
+
+    // Scale the translation component of the transform matrix
+    mat4 scaledTransform = transform;
+    scaledTransform[3] = transform[3] * vec4(scale, scale, scale, 1.0);
+
+    // Apply the scaling matrix to the transformation matrix
+    scaledTransform = scaledTransform * scalingMatrix;
+
+    // Calculate the position in clip space
+    gl_Position = projection * viewworld * scaledTransform * vec4(position, 1.0);
+
 }

--- a/src/compas_viewer/renderer/shaders/instance.vert
+++ b/src/compas_viewer/renderer/shaders/instance.vert
@@ -7,7 +7,17 @@ uniform mat4 viewworld;
 uniform mat4 transform;
 uniform float scale;
 
-void main()
-{
-    gl_Position = projection * viewworld * transform * vec4(position * scale, 1.0);
+void main() {
+    // Create the scaling matrix
+    mat4 scalingMatrix = mat4(scale, 0.0, 0.0, 0.0, 0.0, scale, 0.0, 0.0, 0.0, 0.0, scale, 0.0, 0.0, 0.0, 0.0, 1.0);
+
+    // Scale the translation component of the transform matrix
+    mat4 scaledTransform = transform;
+    scaledTransform[3] = transform[3] * vec4(scale, scale, scale, 1.0);
+
+    // Apply the scaling matrix to the transformation matrix
+    scaledTransform = scaledTransform * scalingMatrix;
+
+    // Calculate the position in clip space
+    gl_Position = projection * viewworld * scaledTransform * vec4(position, 1.0);
 }

--- a/src/compas_viewer/renderer/shaders/instance.vert
+++ b/src/compas_viewer/renderer/shaders/instance.vert
@@ -5,8 +5,9 @@ attribute vec3 position;
 uniform mat4 projection;
 uniform mat4 viewworld;
 uniform mat4 transform;
+uniform float scale;
 
 void main()
 {
-    gl_Position = projection * viewworld * transform * vec4(position, 1.0);
+    gl_Position = projection * viewworld * transform * vec4(position * scale, 1.0);
 }

--- a/src/compas_viewer/renderer/shaders/model.vert
+++ b/src/compas_viewer/renderer/shaders/model.vert
@@ -13,7 +13,20 @@ varying vec3 ec_pos;
 
 void main() {
     vertex_color = color;
-    gl_Position = projection * viewworld * transform * vec4(position * scale, 1.0);
-    ec_pos = vec3(viewworld * transform * vec4(position, 1.0));
 
+    // Create the scaling matrix
+    mat4 scalingMatrix = mat4(scale, 0.0, 0.0, 0.0, 0.0, scale, 0.0, 0.0, 0.0, 0.0, scale, 0.0, 0.0, 0.0, 0.0, 1.0);
+
+    // Scale the translation component of the transform matrix
+    mat4 scaledTransform = transform;
+    scaledTransform[3] = transform[3] * vec4(scale, scale, scale, 1.0);
+
+    // Apply the scaling matrix to the transformation matrix
+    scaledTransform = scaledTransform * scalingMatrix;
+
+    // Calculate the position in clip space
+    gl_Position = projection * viewworld * scaledTransform * vec4(position, 1.0);
+
+    // Calculate the eye coordinates position
+    ec_pos = vec3(viewworld * scaledTransform * vec4(position, 1.0));
 }

--- a/src/compas_viewer/renderer/shaders/model.vert
+++ b/src/compas_viewer/renderer/shaders/model.vert
@@ -6,13 +6,14 @@ attribute vec4 color;
 uniform mat4 projection;
 uniform mat4 viewworld;
 uniform mat4 transform;
+uniform float scale;
 
 varying vec4 vertex_color;
 varying vec3 ec_pos;
 
 void main() {
     vertex_color = color;
-    gl_Position = projection * viewworld * transform * vec4(position, 1.0);
+    gl_Position = projection * viewworld * transform * vec4(position * scale, 1.0);
     ec_pos = vec3(viewworld * transform * vec4(position, 1.0));
 
 }

--- a/src/compas_viewer/renderer/shaders/tag.vert
+++ b/src/compas_viewer/renderer/shaders/tag.vert
@@ -5,6 +5,7 @@ attribute vec3 position;
 uniform mat4 projection;
 uniform mat4 viewworld;
 uniform mat4 transform;
+uniform float scale;
 
 uniform int text_height;
 uniform int text_num;
@@ -12,5 +13,5 @@ uniform int text_num;
 void main()
 {   
     gl_PointSize = text_height * text_num;
-    gl_Position = projection * viewworld * transform * vec4(position, 1.0);
+    gl_Position = projection * viewworld * transform * vec4(position * scale, 1.0);
 }

--- a/src/compas_viewer/renderer/shaders/tag.vert
+++ b/src/compas_viewer/renderer/shaders/tag.vert
@@ -10,8 +10,19 @@ uniform float scale;
 uniform int text_height;
 uniform int text_num;
 
-void main()
-{   
+void main() {
     gl_PointSize = text_height * text_num;
-    gl_Position = projection * viewworld * transform * vec4(position * scale, 1.0);
+
+    // Create the scaling matrix
+    mat4 scalingMatrix = mat4(scale, 0.0, 0.0, 0.0, 0.0, scale, 0.0, 0.0, 0.0, 0.0, scale, 0.0, 0.0, 0.0, 0.0, 1.0);
+
+    // Scale the translation component of the transform matrix
+    mat4 scaledTransform = transform;
+    scaledTransform[3] = transform[3] * vec4(scale, scale, scale, 1.0);
+
+    // Apply the scaling matrix to the transformation matrix
+    scaledTransform = scaledTransform * scalingMatrix;
+
+    // Calculate the position in clip space
+    gl_Position = projection * viewworld * scaledTransform * vec4(position, 1.0);
 }

--- a/src/compas_viewer/viewer.py
+++ b/src/compas_viewer/viewer.py
@@ -38,6 +38,7 @@ class Viewer(Singleton):
         self.ui = UI(self)
 
         self.running = False
+        self._unit = "m"
 
     @property
     def scene(self) -> ViewerScene:
@@ -51,6 +52,24 @@ class Viewer(Singleton):
         if self.running:
             for obj in self._scene.objects:
                 obj.init()
+
+    @property
+    def unit(self) -> str:
+        return self._unit
+
+    @unit.setter
+    def unit(self, unit: str):
+        if unit == "m":
+            self.renderer.scale = 1
+        elif unit == "cm":
+            self.renderer.scale = 0.01
+        elif unit == "mm":
+            self.renderer.scale = 0.001
+        else:
+            raise ValueError("Unit must be one of 'm', 'cm', 'mm'")
+
+        self._unit = unit
+        self.renderer.update()
 
     def show(self):
         self.running = True


### PR DESCRIPTION
Add `unit` for viewer, and `scale` for renderer. 
```
viewer = Viewer()
viewer.unit = "mm"
```
By setting unit to `mm`, it will automatically adjust the render scale (which is handled directly by shaders, so we don't need to scale each individual object)