### PR TITLE
Fix/tag font installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * All color representations are now in `compas.colors.Color`.
 * Reduce the `numpy.array` representation. Mostly use `list` instead for clarity.
 * Comments improved and better type hints.
+* Fixed issue [#200](https://github.com/compas-dev/compas_viewer/issues/200) by adding installation package path.
 
 ### Removed
 * Removed `self.objects` from the `Render` class.`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 compas_viewer = ['config.json']
-"compas_viewer.assets" = ["*.svg", "*.png", "*.ttf"]
+"compas_viewer.assets" = ["*.svg", "*.png"]
+"compas_viewer.assets.fonts" = ["*.ttf"]
 "compas_viewer.renderer.shaders" = ["*.vert", "*.frag"]
 
 # ============================================================================


### PR DESCRIPTION
Change the installation package path in `pyproject.toml`, fixing the issue [#200](https://github.com/compas-dev/compas_viewer/issues/200).

### What type of change is this?

Bug fix in a **backwards-compatible** manner.


