### PR TITLE
work with datastore

### DIFF
--- a/scripts/scene2.py
+++ b/scripts/scene2.py
@@ -1,0 +1,22 @@
+from compas_viewer.viewer import Viewer
+from compas.scene import Scene
+from compas.geometry import Box, Translation
+
+scene = Scene()
+box = Box()
+scene.add(box, color=(255, 0, 0), name="Box1")
+group = scene.add_group(name="My Group")
+obj2 = scene.add(box, color=(0, 0, 255), name="Box2", parent=group)
+obj2.transformation = Translation().from_vector([2, 0, 0])
+
+
+jsonstring = scene.to_jsonstring(pretty=True)
+print(jsonstring)
+
+scene_loaded = Scene.from_jsonstring(jsonstring)
+
+viewer = Viewer()
+viewer.scene = scene_loaded
+
+viewer.show()
+

--- a/src/compas_viewer/scene/geometryobject.py
+++ b/src/compas_viewer/scene/geometryobject.py
@@ -60,11 +60,6 @@ class GeometryObject(ViewerSceneObject, BaseGeometryObject):
 
     geometry: Geometry
 
-    def __init__(self, u: Optional[int] = 16, v: Optional[int] = 16, **kwargs):
-        super().__init__(**kwargs)
-        self.u = u
-        self.v = v
-
     @property
     def facecolor(self) -> Color:
         return self.surfacecolor

--- a/src/compas_viewer/scene/scene.py
+++ b/src/compas_viewer/scene/scene.py
@@ -66,8 +66,8 @@ class ViewerScene(Scene):
     :class:`compas.scene.Scene`
     """
 
-    def __init__(self, name: str = "ViewerScene", context: str = "Viewer"):
-        super().__init__(name=name, context=context)
+    def __init__(self, name: str = "ViewerScene", context: str = "Viewer", **kwargs):
+        super().__init__(name=name, context=context, **kwargs)
         self.instance_colors: dict[tuple[int, int, int], ViewerSceneObject] = {}
         self._instance_colors_generator = instance_colors_generator()
 
@@ -140,10 +140,6 @@ class ViewerScene(Scene):
             Whether to hide the coplanar edges of the mesh.
         use_vertexcolors : bool, optional
             Whether to use vertex color.
-        v : int, optional
-            The number of vertices in the u-direction of non-OCC geometries. Default is 16.
-        u : int, optional
-            The number of vertices in the v-direction of non-OCC geometries. Default is 16.
         **kwargs : dict, optional
             The other possible parameters to be passed to the object.
 
@@ -172,8 +168,6 @@ class ViewerScene(Scene):
             opacity=opacity,
             hide_coplanaredges=hide_coplanaredges,
             use_vertexcolors=use_vertexcolors,
-            v=v,
-            u=u,
             **kwargs,
         )
         return sceneobject
@@ -196,6 +190,7 @@ class ViewerScene(Scene):
         :class:`compas_viewer.scene.Group`
             The group.
         """
+        parent = parent or self.root
         group = Group(name=name, **kwargs)
-        self.add(group, parent=parent)
+        super(Scene, self).add(group, parent=parent)
         return group

--- a/src/compas_viewer/scene/sceneobject.py
+++ b/src/compas_viewer/scene/sceneobject.py
@@ -105,7 +105,6 @@ class ViewerSceneObject(SceneObject, Base):
         self.use_rgba = use_rgba
 
         #  Geometric
-        self.transformation: Optional[Transformation] = None
         self._bounding_box: Optional[list[float]] = None
         self._bounding_box_center: Optional[Point] = None
 

--- a/src/compas_viewer/scene/shapeobject.py
+++ b/src/compas_viewer/scene/shapeobject.py
@@ -50,27 +50,6 @@ class ShapeObject(GeometryObject):
 
     geometry: Shape
 
-    def __init__(self, u: Optional[int] = 16, v: Optional[int] = 16, **kwargs):
-        super().__init__(**kwargs)
-        self.u = u
-        self.v = v
-
-    @property
-    def u(self) -> int:
-        return self.geometry.resolution_u
-
-    @u.setter
-    def u(self, u: int) -> None:
-        self.geometry.resolution_u = u
-
-    @property
-    def v(self) -> int:
-        return self.geometry.resolution_v
-
-    @v.setter
-    def v(self, v: int) -> None:
-        self.geometry.resolution_v = v
-
     @property
     def facecolor(self) -> Color:
         return self.surfacecolor


### PR DESCRIPTION
Trying to work with this PR: https://github.com/compas-dev/compas/pull/1470 , and enable the scene switching like below (which works, but we need to test more complicated cases):

```
from compas_viewer.viewer import Viewer
from compas.scene import Scene
from compas.geometry import Box, Translation

scene = Scene()
box = Box()
scene.add(box, color=(255, 0, 0), name="Box1")
group = scene.add_group(name="My Group")
obj2 = scene.add(box, color=(0, 0, 255), name="Box2", parent=group)
obj2.transformation = Translation().from_vector([2, 0, 0])


jsonstring = scene.to_jsonstring(pretty=True)
print(jsonstring)

scene_loaded = Scene.from_jsonstring(jsonstring)

viewer = Viewer()
viewer.scene = scene_loaded

viewer.show()

```
There is one compromise I had to make, we have to give up ability of set `u`, `v` parameters at object level. 
The reason it that they require access to underlying `item` , which now has to go through `self.scene.datastore[GUID]`. However `self.scene` is not available until `__init__` is finished. I cannot think of a quick and clean way yet, other than remove them all together... let me know if you have better ideas
 