### PR TITLE
Add check on gl_PointCoords before applying circular mask for point rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+* Added a use_circular_points flag in the Shader.draw_point() method to disable circular mask on points on linux because it did not work on opengl-linux. This flag is checked in model.frag before applying the mask on points
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-* Added a use_circular_points flag in the Shader.draw_point() method to disable circular mask on points on linux because it did not work on opengl-linux. This flag is checked in model.frag before applying the mask on points
+* Added a check before applying circular mask on points to be rendered, because with some drivers, gl_PointCoords can be invalid and thus no point is rendered (problem detected on Fedora 43 with intel igpu)
 
 ### Changed
 

--- a/src/compas_viewer/renderer/shaders/model.frag
+++ b/src/compas_viewer/renderer/shaders/model.frag
@@ -14,6 +14,7 @@ in float object_opacity;
 // Uniforms
 uniform float opacity;
 uniform bool is_lighted;
+uniform bool use_circular_points;
 uniform vec3 selection_color;
 uniform int element_type;
 uniform bool is_instance;
@@ -50,7 +51,7 @@ void main() {
     }
 
     // Draw circular points
-    if (element_type == 0) {
+    if (element_type == 0 && use_circular_points) {
         vec2 center = gl_PointCoord - vec2(0.5);
         if (length(center) > 0.5) {
             discard;

--- a/src/compas_viewer/renderer/shaders/model.frag
+++ b/src/compas_viewer/renderer/shaders/model.frag
@@ -51,13 +51,10 @@ void main() {
 
     // Draw circular points if gl_PointCoord allows
     if (element_type == 0) {
-        vec2 pc = gl_PointCoord;
 
-        // Detect broken coords (Mesa/linux case)
-        if (pc.x == 0.0 && pc.y == 0.0) {
-            // fallback: don't discard anything
-        } else {
-            vec2 center = pc - vec2(0.5);
+        // Only apply mask if gl_PointCoord is valid
+        if (gl_PointCoord.x > 1e-5 || gl_PointCoord.y > 1e-5){
+            vec2 center = gl_PointCoord - vec2(0.5);
             if (length(center) > 0.5) {
                 discard;
             }

--- a/src/compas_viewer/renderer/shaders/model.frag
+++ b/src/compas_viewer/renderer/shaders/model.frag
@@ -14,7 +14,6 @@ in float object_opacity;
 // Uniforms
 uniform float opacity;
 uniform bool is_lighted;
-uniform bool use_circular_points;
 uniform vec3 selection_color;
 uniform int element_type;
 uniform bool is_instance;
@@ -50,11 +49,18 @@ void main() {
         alpha = max(alpha, 0.5);
     }
 
-    // Draw circular points
-    if (element_type == 0 && use_circular_points) {
-        vec2 center = gl_PointCoord - vec2(0.5);
-        if (length(center) > 0.5) {
-            discard;
+    // Draw circular points if gl_PointCoord allows
+    if (element_type == 0) {
+        vec2 pc = gl_PointCoord;
+
+        // Detect broken coords (Mesa/linux case)
+        if (pc.x == 0.0 && pc.y == 0.0) {
+            // fallback: don't discard anything
+        } else {
+            vec2 center = pc - vec2(0.5);
+            if (length(center) > 0.5) {
+                discard;
+            }
         }
     }
 

--- a/src/compas_viewer/renderer/shaders/shader.py
+++ b/src/compas_viewer/renderer/shaders/shader.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from typing import Any
 from typing import Union
@@ -214,6 +215,11 @@ class Shader:
         background : bool, optional
             Draw in background.
         """
+        use_circular_points = True
+        if sys.platform == "linux" or sys.platform == "linux2":
+            use_circular_points = False
+        self.uniform1i("use_circular_points", use_circular_points)
+        
         GL.glPointSize(size)
         if elements:
             if background:

--- a/src/compas_viewer/renderer/shaders/shader.py
+++ b/src/compas_viewer/renderer/shaders/shader.py
@@ -214,7 +214,6 @@ class Shader:
         background : bool, optional
             Draw in background.
         """
-        
         GL.glPointSize(size)
         if elements:
             if background:

--- a/src/compas_viewer/renderer/shaders/shader.py
+++ b/src/compas_viewer/renderer/shaders/shader.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 from typing import Any
 from typing import Union

--- a/src/compas_viewer/renderer/shaders/shader.py
+++ b/src/compas_viewer/renderer/shaders/shader.py
@@ -215,10 +215,6 @@ class Shader:
         background : bool, optional
             Draw in background.
         """
-        use_circular_points = True
-        if sys.platform == "linux" or sys.platform == "linux2":
-            use_circular_points = False
-        self.uniform1i("use_circular_points", use_circular_points)
         
         GL.glPointSize(size)
         if elements:


### PR DESCRIPTION
Hi, 
This is a pull request following issue #229 , to fix a visibitily issue of points when on linux. I appears that gl_PointCoord is not always valid, thus when relying on it to apply a circular mask to display round dots for points, the whole point disappears. This fix first checks that the gl_PointCoord is valid before applying the mask, and if it is not valid, the mask is not applied

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
